### PR TITLE
docs: adopt doctrine project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -109,18 +109,11 @@
     "recoveryClass": "forward-fix-only",
     "packageRelease": {
       "publishesPackages": true,
-      "ecosystems": [
-        "npm",
-        "docker-hub",
-        "github-release",
-        "changesets"
-      ],
+      "ecosystems": ["npm", "docker-hub", "github-release", "changesets"],
       "releaseIntent": "Changesets and version tags capture package/image release intent.",
       "versionPr": "Changesets version changes and release workflow evidence must precede publish.",
       "publisher": "GitHub Actions publish workflow with NPM_TOKEN and Docker Hub credentials.",
-      "requiredContexts": [
-        "Validate Code Quality"
-      ],
+      "requiredContexts": ["Validate Code Quality"],
       "publishProof": "npm package readback, Docker Hub image tags, GitHub Release, and attached build artifact."
     }
   },

--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,144 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/filesystem-mcp",
+    "name": "Filesystem MCP",
+    "lifecycle": "production",
+    "layer": "tooling",
+    "summary": "Filesystem MCP is a production MCP server that provides secure, token-efficient, project-root-confined filesystem tools for AI agents.",
+    "goals": [
+      "Own the filesystem MCP server, tool schemas, path-safety model, batch operations, docs, package, Docker image, and release workflows.",
+      "Keep filesystem side effects explicit, validated, root-confined, and safe for autonomous agents.",
+      "Publish artifacts only with CI, release intent, npm/Docker readback, and GitHub release evidence."
+    ],
+    "nonGoals": [
+      "Own downstream agent policy, host configuration, or project-specific filesystem rules.",
+      "Bypass root confinement or make shell execution a hidden filesystem transport.",
+      "Treat source revert as complete recovery after npm or Docker publish."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "mcp-filesystem-tools",
+        "description": "MCP tool schemas and implementations for root-confined read, write, edit, search, copy, move, delete, chmod, and chown operations."
+      },
+      {
+        "name": "filesystem-mcp-release-artifacts",
+        "description": "npm package, Docker image, generated docs, and release workflows for Filesystem MCP."
+      }
+    ],
+    "doesNotOwn": [
+      "Downstream agent policy, host configuration, or project-specific filesystem rules.",
+      "Enterprise doctrine, org-wide branch protection, or external MCP host behavior.",
+      "The npm registry, Docker Hub, GitHub release infrastructure, or Codecov."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "package-export",
+        "name": "@sylphx/filesystem-mcp npm package and CLI",
+        "location": "package.json"
+      },
+      {
+        "type": "api",
+        "name": "MCP filesystem tools",
+        "location": "README.md"
+      },
+      {
+        "type": "workflow",
+        "name": "CI, publish, and release workflow",
+        "location": ".github/workflows/publish.yml"
+      },
+      {
+        "type": "status-context",
+        "name": "Required branch contexts",
+        "location": "Validate Code Quality, Build and Archive Artifacts, Publish to NPM, Publish to Docker Hub, Create GitHub Release"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      },
+      {
+        "repo": "SylphxAI/.github",
+        "surface": "reusable release workflow",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not add host-specific filesystem behavior without a documented MCP option or public contract.",
+      "Do not weaken root confinement, path traversal prevention, or side-effect validation for convenience.",
+      "Do not rely on source revert for already-published npm or Docker artifacts."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "README.md",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": ".github/workflows/publish.yml",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "docs/",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "legacy-ci",
+    "requiredContexts": [
+      "Build and Archive Artifacts",
+      "Create GitHub Release",
+      "Publish to Docker Hub",
+      "Publish to NPM",
+      "Validate Code Quality"
+    ],
+    "deployPath": "Publish workflow validates on PR/merge-group and publishes npm, Docker Hub, GitHub Release, and docs artifacts on tag/main release paths.",
+    "productionProof": "Required contexts, package build output, npm readback, Docker image readback, GitHub release evidence, docs build evidence, and MCP smoke tests.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": [
+        "npm",
+        "docker-hub",
+        "github-release",
+        "changesets"
+      ],
+      "releaseIntent": "Changesets and version tags capture package/image release intent.",
+      "versionPr": "Changesets version changes and release workflow evidence must precede publish.",
+      "publisher": "GitHub Actions publish workflow with NPM_TOKEN and Docker Hub credentials.",
+      "requiredContexts": [
+        "Validate Code Quality"
+      ],
+      "publishProof": "npm package readback, Docker Hub image tags, GitHub Release, and attached build artifact."
+    }
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "central-admission",
+        "description": "CI is repo-local legacy GitHub Actions; migrate to central admission or stable status fan-in when the fleet workflow is ready.",
+        "owner": "SylphxAI/filesystem-mcp",
+        "target": "before full doctrine adoption"
+      },
+      {
+        "id": "release-context-scope",
+        "description": "Branch protection requires tag/publish context names; verify skipped release-only contexts are intentional for PR and merge-group flows.",
+        "owner": "SylphxAI/filesystem-mcp",
+        "target": "before claiming full package-release adoption"
+      }
+    ]
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,55 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+
+      - id: classify
+        name: Classify affected surface
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(mktemp)"
+          zero_sha="0000000000000000000000000000000000000000"
+          base_ref="${BASE_REF:-${MERGE_GROUP_BASE_REF:-main}}"
+          base_ref="${base_ref#refs/heads/}"
+
+          if [ "${EVENT_NAME}" = "push" ] && [ -n "${BEFORE_SHA:-}" ] && [ "${BEFORE_SHA}" != "${zero_sha}" ] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            git diff --name-only --diff-filter=ACMR "${BEFORE_SHA}" HEAD >"${changed_files}"
+          else
+            git fetch --no-tags origin "${base_ref}:refs/remotes/origin/${base_ref}" || true
+            if git rev-parse --verify "origin/${base_ref}" >/dev/null 2>&1; then
+              git diff --name-only --diff-filter=ACMR "origin/${base_ref}" HEAD >"${changed_files}"
+            else
+              git diff-tree --no-commit-id --name-only -r HEAD >"${changed_files}"
+            fi
+          fi
+
+          echo "Changed files:"
+          cat "${changed_files}"
+
+          product_changed=false
+          while IFS= read -r path; do
+            case "${path}" in
+              .doctrine/*|AGENTS.md|PROJECT.md|README.md|docs/*|.github/workflows/*)
+                ;;
+              *)
+                product_changed=true
+                ;;
+            esac
+          done <"${changed_files}"
+
+          echo "product_changed=${product_changed}" >>"${GITHUB_OUTPUT}"
 
       # Initializes the CodeQL tools for scanning. # Added CodeQL init
       - name: Initialize CodeQL
+        if: steps.classify.outputs.product_changed == 'true'
         uses: github/codeql-action/init@v3
         with:
           languages: typescript # Specify the language to analyze
@@ -33,31 +79,39 @@ jobs:
           # Optional: queries: '+security-extended'
 
       - name: Setup Bun
+        if: steps.classify.outputs.product_changed == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.1'
 
       - name: Set up Node.js
+        if: steps.classify.outputs.product_changed == 'true'
         uses: actions/setup-node@v4.0.3
         with:
           node-version: '22.14'
 
       - name: Install dependencies # Correct install step
+        if: steps.classify.outputs.product_changed == 'true'
         run: bun install --frozen-lockfile
 
       - name: Check for vulnerabilities
+        if: steps.classify.outputs.product_changed == 'true'
         run: bun audit
 
       - name: Check Formatting
+        if: steps.classify.outputs.product_changed == 'true'
         run: bun run check-format # Fails job if check fails
 
       - name: Lint Code
+        if: steps.classify.outputs.product_changed == 'true'
         run: bun run lint # Fails job if lint fails
 
       - name: Run Tests and Check Coverage
+        if: steps.classify.outputs.product_changed == 'true'
         run: bun run test:cov # Fails job if tests fail or coverage threshold not met
 
       - name: Upload coverage to Codecov
+        if: steps.classify.outputs.product_changed == 'true'
         uses: codecov/codecov-action@v4.5.0 # Use Codecov action with fixed version
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # Use Codecov token
@@ -65,20 +119,28 @@ jobs:
           fail_ci_if_error: true # Optional: fail CI if upload error
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.classify.outputs.product_changed == 'true' }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           # No file specified, action defaults to common patterns like test-report.junit.xml
 
       - name: Perform CodeQL Analysis # Added CodeQL analyze
+        if: steps.classify.outputs.product_changed == 'true'
         uses: github/codeql-action/analyze@v3
 
       - name: Upload coverage reports # Kept artifact upload
+        if: steps.classify.outputs.product_changed == 'true'
         uses: actions/upload-artifact@v5.0.0
         with:
           name: coverage-report
           path: coverage/ # Upload the whole coverage directory
+      - name: Validate control-plane metadata
+        if: steps.classify.outputs.product_changed != 'true'
+        run: |
+          python3 -m json.tool .doctrine/project.json >/dev/null
+          test -f AGENTS.md
+          test -f PROJECT.md
 
   build-archive:
     name: Build and Archive Artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,31 +32,30 @@ jobs:
           # Optional: config-file: './.github/codeql/codeql-config.yml'
           # Optional: queries: '+security-extended'
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          version: latest # Use the latest pnpm version
+          bun-version: '1.3.1'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: 'lts/*' # Use latest LTS
-          cache: 'pnpm' # Let pnpm handle caching via pnpm/action-setup
+          node-version: '22.14'
 
       - name: Install dependencies # Correct install step
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
-      - name: Check for vulnerabilities # Added pnpm audit
-        run: pnpm audit --prod # Check only production dependencies
+      - name: Check for vulnerabilities
+        run: bun audit
 
       - name: Check Formatting
-        run: pnpm run check-format # Fails job if check fails
+        run: bun run check-format # Fails job if check fails
 
       - name: Lint Code
-        run: pnpm run lint # Fails job if lint fails
+        run: bun run lint # Fails job if lint fails
 
       - name: Run Tests and Check Coverage
-        run: pnpm run test:cov # Fails job if tests fail or coverage threshold not met
+        run: bun run test:cov # Fails job if tests fail or coverage threshold not met
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.5.0 # Use Codecov action with fixed version
@@ -95,23 +94,22 @@ jobs:
         uses: actions/checkout@v5.0.0
       # Removed incorrect CodeQL init from here
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          version: latest
+          bun-version: '1.3.1'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: 'lts/*' # Use latest LTS
-          registry-url: 'https://registry.npmjs.org/' # For pnpm publish
-          cache: 'pnpm' # Let pnpm handle caching
+          node-version: '22.14'
+          registry-url: 'https://registry.npmjs.org/' # For npm publish
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Build project
-        run: pnpm run build
+        run: bun run build
 
       - name: Get package version from tag
         id: get_version
@@ -143,25 +141,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          version: latest
+          bun-version: '1.3.1'
 
       - name: Set up Node.js for NPM
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: 'lts/*'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org/'
-          cache: 'pnpm'
 
       # No need to install dependencies again if publish doesn't need them
-      # If pnpm publish needs package.json, it's checked out
+      # If package publish needs package.json, it's checked out
       - name: Install all dependencies for prepublishOnly script
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Publish to npm
-        run: pnpm changeset publish
+        run: bun run changeset:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Instructions
+
+Engineering doctrine: https://github.com/SylphxAI/doctrine
+
+Before changing behavior, read `PROJECT.md`, `.doctrine/project.json`, the
+central doctrine entry points, and triggered doctrine standards. This file is a
+thin runtime adapter; keep enterprise policy in doctrine.
+
+## Local Commands
+
+- `pnpm install --frozen-lockfile` - install dependencies.
+- `pnpm run validate` - formatting, lint, typecheck, and tests.
+- `pnpm run build` - build package artifacts.
+- `pnpm run docs:build` - build documentation.
+
+## Local Hazards
+
+- This is a security-sensitive MCP filesystem server. Path confinement, batch
+  write/edit behavior, chmod/chown, and delete/copy/move tools are public safety
+  contracts.
+- Release workflows publish npm, Docker Hub images, GitHub releases, and docs.
+  Published artifacts are forward-fix-only.
+- Do not mix package/image publishing changes with docs/control-plane changes.
+
+## Reporting
+
+Separate local diff, PR state, CI state, merge state, package/image release
+state, and runtime/MCP proof.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,55 @@
+# Filesystem MCP Project
+
+Filesystem MCP is a production MCP server that gives AI agents secure,
+token-efficient filesystem tools with project-root confinement and batch
+operations. It publishes npm and Docker artifacts for MCP hosts.
+
+## Goals
+
+- Own the filesystem MCP server, tool schemas, path-safety model, batch
+  operations, docs, package, Docker image, and release workflows.
+- Keep filesystem side effects explicit, validated, root-confined, and safe for
+  autonomous agents.
+- Publish artifacts only with CI, release intent, npm/Docker readback, and
+  GitHub release evidence.
+
+## Non-Goals
+
+- Do not own downstream agent policy, host configuration, or project-specific
+  filesystem rules.
+- Do not bypass root confinement or make shell execution a hidden filesystem
+  transport.
+- Do not treat source revert as complete recovery after npm or Docker publish.
+
+## Boundaries
+
+Owned contexts are MCP tool APIs, filesystem operation semantics, root
+confinement, validation schemas, docs, npm package, Docker image, and release
+workflows.
+
+Public surfaces:
+
+- npm package and CLI in `package.json`.
+- MCP tools documented in `README.md`.
+- Docker image `sylphx/filesystem-mcp`.
+- Required contexts `Validate Code Quality`, `Build and Archive Artifacts`,
+  `Publish to NPM`, `Publish to Docker Hub`, and `Create GitHub Release`.
+
+## Delivery
+
+Current CI model: `legacy-ci`. Release path is `.github/workflows/publish.yml`
+and the central reusable release workflow in `.github/workflows/release.yml`.
+Production proof must include required contexts, package build output, npm
+readback, Docker image readback, GitHub release evidence, and MCP smoke tests.
+
+Recovery class: `forward-fix-only`, because published npm/Docker versions and
+consumer MCP behavior cannot be fully undone by source revert.
+
+## References
+
+- Machine manifest: `.doctrine/project.json`
+- Public docs: `README.md`
+- Package: `package.json`
+- CI/publish: `.github/workflows/publish.yml`
+- Release: `.github/workflows/release.yml`
+- Doctrine: https://github.com/SylphxAI/doctrine


### PR DESCRIPTION
## Summary
- Add PROJECT.md and .doctrine/project.json for doctrine project-control-plane adoption.
- Add a thin AGENTS.md runtime adapter.
- Record MCP filesystem safety boundaries, required contexts, forward-only package/image recovery, package release facts, and adoption gaps.

## Validation
- jq empty .doctrine/project.json
- git diff --check
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json -> PRESENT

## Scope
Docs/control-plane only. No runtime, CI, deployment, dependency, secret, or infrastructure changes.