### PR TITLE
docs: add MCP family SOTA roadmap

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -49,6 +49,7 @@ consumer MCP behavior cannot be fully undone by source revert.
 
 - Machine manifest: `.doctrine/project.json`
 - Public docs: `README.md`
+- SOTA family roadmap: `docs/roadmap/sota-family-roadmap.md`
 - Package: `package.json`
 - CI/publish: `.github/workflows/publish.yml`
 - Release: `.github/workflows/release.yml`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Batch operations** • **Project root safety** • **Token optimized** • **Zod validation**
 
-[Quick Start](#-quick-start) • [Installation](#-installation) • [Tools](#-features)
+[Quick Start](#-quick-start) • [Installation](#-installation) • [Tools](#-features) • [Roadmap](docs/roadmap/sota-family-roadmap.md)
 
 <a href="https://glama.ai/mcp/servers/@sylphx/filesystem-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@sylphx/filesystem-mcp/badge" alt="Filesystem MCP Server" />

--- a/docs/adr/ADR-194-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-194-mcp-family-sota-roadmap.md
@@ -1,0 +1,37 @@
+# ADR-194: Adopt Filesystem MCP Family SOTA Roadmap
+
+Date: 2026-07-09  
+Status: Proposed in PR #194  
+Slug: mcp-family-sota-roadmap
+
+## Context
+
+Filesystem MCP is the safe local operation engine in the SylphxAI MCP family.
+It needs a repo-local roadmap that sharpens its responsibility for root-scoped
+filesystem access and guarded writes while preserving separation from code
+retrieval, architecture understanding, media extraction, and deliberation.
+
+## Decision
+
+Adopt `docs/roadmap/sota-family-roadmap.md` as the local roadmap for Filesystem
+MCP's family role.
+
+Filesystem MCP owns root confinement, path policy, read/write operations,
+search, batch behavior, diff apply semantics, operation evidence, and release
+artifacts for the filesystem server.
+
+## Consequences
+
+- Architecture Reader and CodeRAG can identify relevant files, but Filesystem
+  MCP owns safe filesystem side effects.
+- Rust is the target for path canonicalization, policy, walking, search, IO,
+  hashing, diff preview/apply, and operation ledgers.
+- Write-capable tools require conflict detection, auditability, and clear
+  recovery semantics.
+- Shell execution must not become a hidden transport for filesystem behavior.
+
+## Verification
+
+- Roadmap added at `docs/roadmap/sota-family-roadmap.md`.
+- README and PROJECT link to the roadmap.
+- Docs-only validation: `git diff --check`.

--- a/docs/adr/ADR-194-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-194-mcp-family-sota-roadmap.md
@@ -1,7 +1,7 @@
 # ADR-194: Adopt Filesystem MCP Family SOTA Roadmap
 
-Date: 2026-07-09  
-Status: Proposed in PR #194  
+Date: 2026-07-09
+Status: Proposed in PR #194
 Slug: mcp-family-sota-roadmap
 
 ## Context

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -17,13 +17,13 @@ through guarded operations.
 
 ## Family Fit
 
-| Project | Relationship |
-| --- | --- |
-| Architecture Reader MCP | Identifies architecture impact and affected files. Filesystem MCP performs safe reads or edits when an agent acts. |
-| CodeRAG | Finds relevant code evidence. Filesystem MCP applies file operations and can expose exact file content to retrieval workflows. |
-| Reader MCPs | Read media and documents. Filesystem MCP owns generic filesystem access and write safety, not media interpretation. |
-| Consultant MCP | Reviews high-risk operations and policies. Filesystem MCP provides operation evidence and write ledgers. |
-| Smart Reader MCP | Routes media reads. Filesystem MCP stays broader and owns root-scoped filesystem tools. |
+| Project                 | Relationship                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Architecture Reader MCP | Identifies architecture impact and affected files. Filesystem MCP performs safe reads or edits when an agent acts.             |
+| CodeRAG                 | Finds relevant code evidence. Filesystem MCP applies file operations and can expose exact file content to retrieval workflows. |
+| Reader MCPs             | Read media and documents. Filesystem MCP owns generic filesystem access and write safety, not media interpretation.            |
+| Consultant MCP          | Reviews high-risk operations and policies. Filesystem MCP provides operation evidence and write ledgers.                       |
+| Smart Reader MCP        | Routes media reads. Filesystem MCP stays broader and owns root-scoped filesystem tools.                                        |
 
 ## SOTA End State
 

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -3,12 +3,13 @@
 Status: adoption plan  
 Owner: Filesystem MCP  
 Scope: repo-local future plan and its role in the SylphxAI MCP family
+Decision record: `docs/adr/ADR-194-mcp-family-sota-roadmap.md`
 
 ## Family Role
 
 Filesystem MCP is the safe local operation engine for the MCP family. It gives
-agents root-confined read, search, list, edit, copy, move, delete, chmod, and
-chown capabilities with explicit validation and auditability.
+agents root-confined read, search, list, edit, duplicate-file, move, delete,
+chmod, and chown capabilities with explicit validation and auditability.
 
 It is the execution-side complement to evidence tools. Other MCPs help agents
 understand files and decisions; Filesystem MCP changes the local project only

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -1,0 +1,96 @@
+# SOTA Family Roadmap
+
+Status: adoption plan  
+Owner: Filesystem MCP  
+Scope: repo-local future plan and its role in the SylphxAI MCP family
+
+## Family Role
+
+Filesystem MCP is the safe local operation engine for the MCP family. It gives
+agents root-confined read, search, list, edit, copy, move, delete, chmod, and
+chown capabilities with explicit validation and auditability.
+
+It is the execution-side complement to evidence tools. Other MCPs help agents
+understand files and decisions; Filesystem MCP changes the local project only
+through guarded operations.
+
+## Family Fit
+
+| Project | Relationship |
+| --- | --- |
+| Architecture Reader MCP | Identifies architecture impact and affected files. Filesystem MCP performs safe reads or edits when an agent acts. |
+| CodeRAG | Finds relevant code evidence. Filesystem MCP applies file operations and can expose exact file content to retrieval workflows. |
+| Reader MCPs | Read media and documents. Filesystem MCP owns generic filesystem access and write safety, not media interpretation. |
+| Consultant MCP | Reviews high-risk operations and policies. Filesystem MCP provides operation evidence and write ledgers. |
+| Smart Reader MCP | Routes media reads. Filesystem MCP stays broader and owns root-scoped filesystem tools. |
+
+## SOTA End State
+
+Filesystem MCP should become the highest-trust local filesystem server for
+agents: fast enough for large repositories, safe enough for autonomous writes,
+and auditable enough to reconstruct every side effect.
+
+## Runtime Direction
+
+Rust should own path canonicalization, root confinement, symlink policy,
+directory walking, streaming IO, hashing, search, diff preview, diff apply, and
+operation ledgers. The TypeScript adapter can remain while tool schemas and
+release compatibility are preserved.
+
+WASM is not the default runtime for filesystem tools because the host capability
+model is the product boundary. WASM may be used only for sandboxed transforms
+that cannot escape the host policy engine.
+
+## Roadmap
+
+### Phase 0: Safety Contract
+
+- Document every read and write tool with exact side-effect semantics.
+- Add fixtures for symlink escape, path traversal, hidden files, binary files,
+  oversized files, permission errors, and stale-write conflicts.
+- Add dry-run examples for write-capable tools.
+- Add operation evidence fields: root, resolved path, before hash, after hash,
+  line range, operation id, and policy decision.
+
+### Phase 1: Rust Policy And IO Core
+
+- Implement canonical path and root policy in Rust.
+- Add fast ignore-aware directory walk and content search.
+- Add streaming reads and bounded memory behavior.
+- Add deterministic diff preview and apply primitives.
+
+### Phase 2: Write Integrity And Audit
+
+- Require exact current hash or conflict detection for write operations.
+- Add operation ledger entries for every side effect.
+- Add rollback metadata where safe and honest recovery warnings where not safe.
+- Add structured output for partial success and per-file failure.
+
+### Phase 3: Policy Profiles
+
+- Add read-only, write-approved, CI-safe, and high-risk-denied profiles.
+- Add allowlist and denylist configuration with tests.
+- Add policy export so other MCPs and agents know available capabilities.
+
+### Phase 4: Native Distribution
+
+- Ship platform-specific optional binary packages.
+- Add `doctor` diagnostics for native engine, permissions, path policy, and
+  unsupported filesystem features.
+- Publish benchmark fixtures for walk, search, read batch, write batch, and diff
+  apply operations.
+
+## Star And Adoption Strategy
+
+The public promise is safe speed: agents can work with files without falling
+back to unbounded shell commands. Star growth comes from trustable safety
+examples, clear write semantics, strong path-confinement proof, and immediate
+batch-operation wins.
+
+## Validation Gates
+
+- Symlink escape attempts are denied.
+- Writes detect stale content before mutating files.
+- Search respects ignore and policy rules.
+- Large repositories meet published walk and search latency gates.
+- Audit output reconstructs every write operation.

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -1,7 +1,7 @@
 # SOTA Family Roadmap
 
-Status: adoption plan  
-Owner: Filesystem MCP  
+Status: adoption plan
+Owner: Filesystem MCP
 Scope: repo-local future plan and its role in the SylphxAI MCP family
 Decision record: `docs/adr/ADR-194-mcp-family-sota-roadmap.md`
 


### PR DESCRIPTION
## Summary
- add repo-local SOTA family roadmap for Filesystem MCP
- add ADR-194 adopting the roadmap and clarifying the safe-local-operation role
- link the roadmap from README and PROJECT

## Validation
- local: git diff origin/main...HEAD --check
- local: Prettier check on changed roadmap/ADR passed
- local attempted: pnpm install --frozen-lockfile (blocked by pre-existing pnpm-lock/package.json drift)
- local attempted: bun run validate (blocked by pre-existing full-repo Prettier drift outside this change)
- remote CI: Validate Code Quality passed