### PR TITLE
docs: align filesystem roadmap with Rust MCP runtime

### DIFF
--- a/docs/adr/ADR-194-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-194-mcp-family-sota-roadmap.md
@@ -25,10 +25,17 @@ artifacts for the filesystem server.
 - Architecture Reader and CodeRAG can identify relevant files, but Filesystem
   MCP owns safe filesystem side effects.
 - Rust is the target for path canonicalization, policy, walking, search, IO,
-  hashing, diff preview/apply, and operation ledgers.
+  hashing, diff preview/apply, operation ledgers, and MCP serving through
+  `modelcontextprotocol/rust-sdk` / `rmcp`.
 - Write-capable tools require conflict detection, auditability, and clear
   recovery semantics.
 - Shell execution must not become a hidden transport for filesystem behavior.
+
+## Amendment: Rust-Native MCP Runtime
+
+The family runtime direction now targets Rust MCP servers. Filesystem MCP may
+keep TypeScript compatibility wrappers during migration, but the target MCP
+server runtime is Rust with `rmcp`.
 
 ## Verification
 

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -35,8 +35,11 @@ and auditable enough to reconstruct every side effect.
 
 Rust should own path canonicalization, root confinement, symlink policy,
 directory walking, streaming IO, hashing, search, diff preview, diff apply, and
-operation ledgers. The TypeScript adapter can remain while tool schemas and
-release compatibility are preserved.
+operation ledgers. It should also own MCP serving through
+`modelcontextprotocol/rust-sdk` / `rmcp`.
+
+TypeScript can remain only as a compatibility wrapper, generated client surface,
+or package-transition layer. It is not the target MCP adapter runtime.
 
 WASM is not the default runtime for filesystem tools because the host capability
 model is the product boundary. WASM may be used only for sandboxed transforms
@@ -59,6 +62,7 @@ that cannot escape the host policy engine.
 - Add fast ignore-aware directory walk and content search.
 - Add streaming reads and bounded memory behavior.
 - Add deterministic diff preview and apply primitives.
+- Add Rust MCP handlers for read, search, diff preview, and guarded writes.
 
 ### Phase 2: Write Integrity And Audit
 


### PR DESCRIPTION
## Summary
- Amends Filesystem MCP roadmap/ADR to target Rust MCP serving via modelcontextprotocol/rust-sdk / rmcp.
- Keeps TypeScript only as migration compatibility wrapper.

## Validation
- git diff --check
- wording sweep for old TypeScript adapter language