### PR TITLE
fix(release): inline Changesets release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,50 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
-    permissions:
-      actions: write
-      contents: write
-      pull-requests: write
-    uses: SylphxAI/.github/.github/workflows/release.yml@main
-    secrets: inherit
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.12'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Rust core and MCP server
+        run: bun run build:rust
+
+      - name: Release gate
+        run: bun run benchmark:release-gate
+
+      - name: Create release PR or publish
+        uses: changesets/action@v1
+        with:
+          version: bun run version-packages
+          publish: bun run release
+          title: 'chore(release): version packages'
+          commit: 'chore(release): version packages'
+          createGithubReleases: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
 		"prepublishOnly": "bun run clean && bun run build && bun run build:rust",
 		"changeset": "changeset",
 		"changeset:version": "changeset version",
-		"changeset:publish": "changeset publish"
+		"changeset:publish": "changeset publish",
+		"version-packages": "changeset version",
+		"release": "bun run build && bun run build:rust && bun run benchmark:release-gate && changeset publish"
 	},
 	"homepage": "https://github.com/SylphxAI/filesystem-mcp#readme",
 	"repository": {


### PR DESCRIPTION
## Summary
- Replace `uses: SylphxAI/.github/.../release.yml` (startup_failure, 0 jobs) with inline `changesets/action` workflow matching image-reader-mcp.
- Add `version-packages` and `release` scripts for Changesets version PR + npm publish.
- Preflight: `build:rust` + `benchmark:release-gate` before version/publish.

## Why
`release.yml` on main has failed every push since the Rust port with `startup_failure` and no job logs, blocking `@sylphx/filesystem-mcp` npm publish.

## Test plan
- [ ] CI validate green on PR
- [ ] Merge → Release workflow creates version PR or publishes
- [ ] npm readback `@sylphx/filesystem-mcp`