### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/rust-default-public-launch.md
+++ b/.changeset/rust-default-public-launch.md
@@ -1,5 +1,0 @@
----
-"@sylphx/filesystem-mcp": minor
----
-
-Ship Rust-default rmcp transport with native read_content, write_content, and stat_items on the primary path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0
+
+### Minor Changes
+
+- 09de01f: Ship Rust-default rmcp transport with native read_content, write_content, and stat_items on the primary path.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sylphx/filesystem-mcp",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"description": "An MCP server providing filesystem tools relative to a project root.",
 	"type": "module",
 	"main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Consumes `.changeset/rust-default-public-launch.md` and bumps `@sylphx/filesystem-mcp` to **0.7.0** for Rust-default rmcp commercial launch.

## Why
`changesets/action` on `release.yml` cannot open PRs under org policy (`GitHub Actions is not permitted to create or approve pull requests`). This PR mirrors the bot-owned version step so merge can trigger publish.

## Test plan
- [ ] CI green
- [ ] Merge → `release.yml` publishes `@sylphx/filesystem-mcp@0.7.0`
- [ ] npm readback