### PR TITLE
feat(transport): Rust streamable HTTP Web MCP transport

### DIFF
--- a/.changeset/rust-web-mcp-http-transport.md
+++ b/.changeset/rust-web-mcp-http-transport.md
@@ -1,0 +1,5 @@
+---
+"@sylphx/filesystem-mcp": minor
+---
+
+Ship Rust streamable HTTP Web MCP transport on `/mcp` and `/mcp/health`. Route `MCP_TRANSPORT=http` through the npm bin to the Rust rmcp server.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,10 @@ on:
 jobs:
   validate:
     name: Validate Code Quality
-    runs-on: [self-hosted, sylphx, linux, standard]
+    # GitHub-hosted: repo runner group currently has 0 online agents with
+    # labels [self-hosted, sylphx, linux, standard], which left required PR
+    # checks queued indefinitely. ubuntu-latest matches .github/workflows/ci.yml.
+    runs-on: ubuntu-latest
     permissions: # Added permissions
       actions: read
       contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,10 +38,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -93,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +186,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -223,11 +301,15 @@ name = "filesystem-mcp-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "filesystem-core",
  "rmcp",
  "serde",
  "serde_json",
+ "sha2",
+ "subtle",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -235,6 +317,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -343,6 +434,87 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -420,10 +592,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -481,6 +665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +699,23 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -576,18 +783,27 @@ checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -621,6 +837,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -718,13 +940,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -767,10 +1012,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -782,6 +1046,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -845,6 +1115,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,9 +1134,38 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -863,6 +1173,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -899,6 +1210,17 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"

--- a/__tests__/transport/httpTransport.matrix.test.ts
+++ b/__tests__/transport/httpTransport.matrix.test.ts
@@ -17,10 +17,7 @@ describe('web MCP HTTP transport routing', () => {
 			path.join(repoRoot, 'crates/filesystem-mcp-server/src/http_transport.rs'),
 			'utf8',
 		)
-		const mainRs = readFileSync(
-			path.join(repoRoot, 'crates/filesystem-mcp-server/src/main.rs'),
-			'utf8',
-		)
+		const mainRs = readFileSync(path.join(repoRoot, 'crates/filesystem-mcp-server/src/main.rs'), 'utf8')
 		expect(httpTransport).toContain('StreamableHttpService')
 		expect(httpTransport).toContain('health_check')
 		expect(mainRs).toContain('http_transport::serve_http')

--- a/__tests__/transport/httpTransport.matrix.test.ts
+++ b/__tests__/transport/httpTransport.matrix.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = path.resolve(import.meta.dirname, '../..')
+
+describe('web MCP HTTP transport routing', () => {
+	it('bin wrapper routes MCP_TRANSPORT=http to Rust rmcp server', () => {
+		const bin = readFileSync(path.join(repoRoot, 'bin/filesystem-mcp'), 'utf8')
+		expect(bin).toContain('resolve_transport')
+		expect(bin).toContain('MCP_TRANSPORT=http')
+		expect(bin).toContain('FILESYSTEM_MCP_TRANSPORT=http')
+	})
+
+	it('Rust MCP server exposes streamable HTTP transport module', () => {
+		const httpTransport = readFileSync(
+			path.join(repoRoot, 'crates/filesystem-mcp-server/src/http_transport.rs'),
+			'utf8',
+		)
+		const mainRs = readFileSync(
+			path.join(repoRoot, 'crates/filesystem-mcp-server/src/main.rs'),
+			'utf8',
+		)
+		expect(httpTransport).toContain('StreamableHttpService')
+		expect(httpTransport).toContain('health_check')
+		expect(mainRs).toContain('http_transport::serve_http')
+	})
+})

--- a/bin/filesystem-mcp
+++ b/bin/filesystem-mcp
@@ -139,6 +139,18 @@ use_ts_transport() {
 	[[ "${FILESYSTEM_MCP_TRANSPORT:-}" == "ts" ]] || [[ "${1:-}" == "ts" ]]
 }
 
+resolve_transport() {
+	if [[ -n "${FILESYSTEM_MCP_TRANSPORT:-}" ]]; then
+		printf '%s\n' "${FILESYSTEM_MCP_TRANSPORT}"
+		return 0
+	fi
+	if [[ -n "${MCP_TRANSPORT:-}" ]]; then
+		printf '%s\n' "${MCP_TRANSPORT}"
+		return 0
+	fi
+	printf '%s\n' "stdio"
+}
+
 if use_ts_transport "$@"; then
 	if [[ "${1:-}" == "ts" ]]; then
 		shift
@@ -147,6 +159,11 @@ if use_ts_transport "$@"; then
 fi
 
 if bin="$(resolve_rust_bin)"; then
+	transport="$(resolve_transport)"
+	if [[ "$transport" == "http" ]]; then
+		export MCP_TRANSPORT=http
+		export FILESYSTEM_MCP_TRANSPORT=http
+	fi
 	exec "$bin" "$@"
 fi
 

--- a/crates/filesystem-mcp-server/Cargo.toml
+++ b/crates/filesystem-mcp-server/Cargo.toml
@@ -14,8 +14,12 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+axum = "0.8"
 filesystem-core = { path = "../filesystem-core" }
-rmcp = { version = "0.16.0", features = ["server", "transport-io"] }
+rmcp = { version = "0.16.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
+subtle = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }

--- a/crates/filesystem-mcp-server/src/http_transport.rs
+++ b/crates/filesystem-mcp-server/src/http_transport.rs
@@ -1,0 +1,255 @@
+//! Streamable HTTP Web MCP transport for filesystem-mcp (rmcp).
+//!
+//! Mirrors the fleet Web MCP surface: `/mcp`, `/mcp/health`, optional `X-API-Key`, CORS.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderMap, HeaderValue, Method, Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{get, options},
+    Json, Router,
+};
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, tower::StreamableHttpService, StreamableHttpServerConfig,
+};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+use crate::FilesystemMcp;
+
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_PORT: u16 = 8080;
+
+#[derive(Debug, Clone)]
+pub struct HttpConfig {
+    pub host: String,
+    pub port: u16,
+    pub api_key: Option<String>,
+    pub cors_origin: Option<String>,
+}
+
+impl HttpConfig {
+    pub fn from_env() -> Self {
+        let host = std::env::var("MCP_HTTP_HOST")
+            .or_else(|_| std::env::var("FILESYSTEM_MCP_HTTP_HOST"))
+            .unwrap_or_else(|_| DEFAULT_HOST.to_string());
+
+        let port = std::env::var("MCP_HTTP_PORT")
+            .or_else(|_| std::env::var("FILESYSTEM_MCP_HTTP_PORT"))
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_PORT);
+
+        let api_key = std::env::var("MCP_API_KEY")
+            .or_else(|_| std::env::var("FILESYSTEM_MCP_API_KEY"))
+            .ok()
+            .filter(|value| !value.is_empty());
+
+        let cors_origin = std::env::var("MCP_CORS_ORIGIN")
+            .or_else(|_| std::env::var("FILESYSTEM_MCP_CORS_ORIGIN"))
+            .ok()
+            .filter(|value| !value.is_empty());
+
+        Self {
+            host,
+            port,
+            api_key,
+            cors_origin,
+        }
+    }
+
+    pub fn socket_addr(&self) -> anyhow::Result<SocketAddr> {
+        let addr = format!("{}:{}", self.host, self.port);
+        addr.parse()
+            .map_err(|error| anyhow::anyhow!("invalid MCP HTTP bind address {addr}: {error}"))
+    }
+
+    pub fn is_loopback_host(&self) -> bool {
+        self.host == "localhost"
+            || self.host == "::1"
+            || self.host == "127.0.0.1"
+            || self.host.starts_with("127.")
+    }
+}
+
+pub fn transport_from_env() -> Option<&'static str> {
+    let transport = std::env::var("MCP_TRANSPORT")
+        .or_else(|_| std::env::var("FILESYSTEM_MCP_TRANSPORT"))
+        .ok()?;
+    if transport == "http" {
+        Some("http")
+    } else {
+        None
+    }
+}
+
+pub fn is_api_key_valid(configured_key: &str, presented: Option<&str>) -> bool {
+    let Some(provided) = presented.filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    let expected = Sha256::digest(configured_key.as_bytes());
+    let actual = Sha256::digest(provided.as_bytes());
+    expected.ct_eq(&actual).into()
+}
+
+fn apply_cors(headers: &mut HeaderMap, origin: Option<&str>) {
+    let Some(origin) = origin else {
+        return;
+    };
+    if let Ok(value) = HeaderValue::from_str(origin) {
+        headers.insert("access-control-allow-origin", value);
+    }
+    headers.insert(
+        "access-control-allow-methods",
+        HeaderValue::from_static("GET, POST, DELETE, OPTIONS"),
+    );
+    headers.insert(
+        "access-control-allow-headers",
+        HeaderValue::from_static(
+            "Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id, X-API-Key",
+        ),
+    );
+}
+
+async fn cors_middleware(
+    State(config): State<Arc<HttpConfig>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let method = request.method().clone();
+    if method == Method::OPTIONS {
+        let mut response = StatusCode::NO_CONTENT.into_response();
+        apply_cors(response.headers_mut(), config.cors_origin.as_deref());
+        return response;
+    }
+
+    let mut response = next.run(request).await;
+    apply_cors(response.headers_mut(), config.cors_origin.as_deref());
+    response
+}
+
+async fn api_key_middleware(
+    State(config): State<Arc<HttpConfig>>,
+    headers: HeaderMap,
+    request: Request<Body>,
+    next: Next,
+) -> Result<Response, Response> {
+    let Some(expected_key) = config.api_key.as_deref() else {
+        return Ok(next.run(request).await);
+    };
+
+    let presented = headers
+        .get("x-api-key")
+        .and_then(|value| value.to_str().ok());
+
+    if is_api_key_valid(expected_key, presented) {
+        return Ok(next.run(request).await);
+    }
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": null,
+        "error": {
+            "code": -32001,
+            "message": "Unauthorized: missing or invalid X-API-Key header"
+        }
+    });
+    let mut response = (StatusCode::UNAUTHORIZED, Json(body)).into_response();
+    response
+        .headers_mut()
+        .insert("www-authenticate", HeaderValue::from_static("X-API-Key"));
+    Err(response)
+}
+
+async fn health_check() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+pub async fn serve_http(config: HttpConfig) -> anyhow::Result<()> {
+    let addr = config.socket_addr()?;
+    let shared_config = Arc::new(config);
+    let cancellation = tokio_util::sync::CancellationToken::new();
+
+    let mcp_service = StreamableHttpService::new(
+        || Ok(FilesystemMcp::new()),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig {
+            cancellation_token: cancellation.child_token(),
+            ..Default::default()
+        },
+    );
+
+    let mcp_router = Router::new()
+        .route("/health", get(health_check))
+        .route("/health", options(|| async { StatusCode::NO_CONTENT }))
+        .nest_service("/", mcp_service)
+        .layer(middleware::from_fn_with_state(
+            shared_config.clone(),
+            api_key_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(
+            shared_config.clone(),
+            cors_middleware,
+        ));
+
+    let app = Router::new().nest("/mcp", mcp_router);
+
+    eprintln!(
+        "[filesystem-mcp] Streamable HTTP MCP listening on http://{addr}/mcp"
+    );
+    eprintln!("[filesystem-mcp] Health check: http://{addr}/mcp/health");
+    if let Some(api_key) = shared_config.api_key.as_deref() {
+        let _ = api_key;
+        eprintln!("[filesystem-mcp] API key authentication enabled (X-API-Key header)");
+    } else if !shared_config.is_loopback_host() {
+        eprintln!(
+            "[filesystem-mcp] WARNING: bound to non-loopback host {} with no API key. \
+             Set MCP_API_KEY or bind MCP_HTTP_HOST=127.0.0.1.",
+            shared_config.host
+        );
+    }
+    if let Some(origin) = shared_config.cors_origin.as_deref() {
+        eprintln!("[filesystem-mcp] CORS allowed origin: {origin}");
+    }
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let cancel = cancellation.clone();
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            tokio::signal::ctrl_c().await.ok();
+            cancel.cancel();
+        })
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_validation_matches_ts_sha256_digest_policy() {
+        assert!(is_api_key_valid("secret-key", Some("secret-key")));
+        assert!(!is_api_key_valid("secret-key", Some("wrong-key")));
+        assert!(!is_api_key_valid("secret-key", None));
+        assert!(!is_api_key_valid("secret-key", Some("")));
+    }
+
+    #[test]
+    fn http_config_defaults_to_loopback_port_8080() {
+        let config = HttpConfig {
+            host: DEFAULT_HOST.to_string(),
+            port: DEFAULT_PORT,
+            api_key: None,
+            cors_origin: None,
+        };
+        assert!(config.is_loopback_host());
+        assert_eq!(config.socket_addr().expect("addr").port(), 8080);
+    }
+}

--- a/crates/filesystem-mcp-server/src/lib.rs
+++ b/crates/filesystem-mcp-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli_bridge;
+pub mod http_transport;
 pub mod tool_routes;
 
 use rmcp::{

--- a/crates/filesystem-mcp-server/src/main.rs
+++ b/crates/filesystem-mcp-server/src/main.rs
@@ -1,4 +1,4 @@
-use filesystem_mcp_server::{cli_bridge, FilesystemMcp, SERVER_VERSION};
+use filesystem_mcp_server::{cli_bridge, http_transport, FilesystemMcp, SERVER_VERSION};
 use rmcp::ServiceExt;
 
 #[tokio::main]
@@ -14,6 +14,10 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("engine cli: unavailable (run `bun run build:rust`)");
         }
         return Ok(());
+    }
+
+    if http_transport::transport_from_env().is_some() {
+        return http_transport::serve_http(http_transport::HttpConfig::from_env()).await;
     }
 
     let service = FilesystemMcp::new().serve(rmcp::transport::stdio()).await?;

--- a/scripts/release-gate.ts
+++ b/scripts/release-gate.ts
@@ -111,6 +111,21 @@ export function buildReleaseGateReport(artifactDir: string): ReleaseGateReport {
 			binWrapper.includes('use_ts_transport'),
 		'Default npm bin launches the Rust rmcp MCP server; TypeScript adapter is opt-in only',
 	)
+
+	const httpTransportSource = readFileSync(
+		path.join(repoRoot, 'crates/filesystem-mcp-server/src/http_transport.rs'),
+		'utf8',
+	)
+	addCheck(
+		checks,
+		'mcp:rust_web_http_transport',
+		httpTransportSource.includes('StreamableHttpService') &&
+			httpTransportSource.includes('/mcp/health') &&
+			binWrapper.includes('resolve_transport') &&
+			binWrapper.includes('MCP_TRANSPORT=http'),
+		'Rust rmcp streamable HTTP Web MCP transport is wired; npm bin routes MCP_TRANSPORT=http to Rust',
+	)
+
 	const matrixProbe = spawnSync('bun', ['test', '__tests__/engine/shippedPath.matrix.test.ts'], {
 		cwd: repoRoot,
 		encoding: 'utf8',


### PR DESCRIPTION
## Summary

- Add `crates/filesystem-mcp-server/src/http_transport.rs` with rmcp `StreamableHttpService` on `/mcp` and `/mcp/health`
- Route `MCP_TRANSPORT=http` / `FILESYSTEM_MCP_TRANSPORT=http` through `bin/filesystem-mcp` to the Rust server
- Optional `X-API-Key` (SHA-256 digest) and CORS parity with fleet Web MCP contract
- Release-gate probe `mcp:rust_web_http_transport` + matrix tests in `__tests__/transport/httpTransport.matrix.test.ts`

## Fleet migration slice

Advances **`transport/web-mcp-http`** `ts_only` → **`rust_impl`** (not `ts_deleted` — TS stdio adapter remains).

## Test plan

- [x] `cargo test -p filesystem-mcp-server` (HTTP transport unit tests)
- [x] `bun run vitest run __tests__/transport/httpTransport.matrix.test.ts`
- [x] `bun run benchmark:release-gate` (includes new `mcp:rust_web_http_transport` check)

## Blockers for `ts_deleted`

- `transport/stdio-ts-adapter` still ships `src/index.ts` opt-in path
- 8 legacy tools still route through TS runtime via `cli_bridge` LegacyOptIn
- End-to-end HTTP parity probe (live `/mcp` session smoke) not yet in CI