### PR TITLE
fix(release): multi-arch native optionalDependencies (0.7.1)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
-  "commit": false,
-  "fixed": [],
-  "linked": [],
-  "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": []
+	"$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+	"changelog": "@changesets/cli/changelog",
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "public",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": []
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,11 @@
 {
-	"$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-	"changelog": "@changesets/cli/changelog",
-	"commit": false,
-	"fixed": [],
-	"linked": [],
-	"access": "public",
-	"baseBranch": "main",
-	"updateInternalDependencies": "patch",
-	"ignore": []
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
 }

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,149 @@
+name: Native multi-arch
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'bin/filesystem-mcp'
+      - 'npm/**'
+      - 'scripts/stage-rust-mcp.ts'
+      - 'scripts/assemble-multiarch-natives.ts'
+      - '.github/workflows/native-build.yml'
+      - '.github/workflows/release.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'bin/filesystem-mcp'
+      - 'npm/**'
+      - 'scripts/stage-rust-mcp.ts'
+      - 'scripts/assemble-multiarch-natives.ts'
+      - '.github/workflows/native-build.yml'
+      - '.github/workflows/release.yml'
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          # Both Darwin targets on macos-latest (arm64 host); x86_64 is
+          # cross-compiled. macos-13 (Intel) runners queue for long periods.
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            platform_key: darwin-arm64
+          - host: macos-latest
+            target: x86_64-apple-darwin
+            platform_key: darwin-x64
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            platform_key: linux-x64-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            platform_key: linux-arm64-gnu
+
+    name: Build ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: native-${{ matrix.settings.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            native-${{ matrix.settings.target }}-
+
+      - name: Build release natives
+        run: |
+          set -euo pipefail
+          cargo build --release -p filesystem-mcp-server --target ${{ matrix.settings.target }}
+          BIN="target/${{ matrix.settings.target }}/release/filesystem-mcp-server"
+          test -f "$BIN"
+          chmod +x "$BIN"
+          file "$BIN" || true
+          # Fail-closed: binary must be non-trivial
+          test "$(wc -c < "$BIN")" -gt 100000
+          mkdir -p "native-out"
+          cp "$BIN" "native-out/filesystem-mcp-server"
+          chmod +x "native-out/filesystem-mcp-server"
+
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: filesystem-mcp-native-${{ matrix.settings.target }}
+          path: native-out/filesystem-mcp-server
+          if-no-files-found: error
+          retention-days: 14
+
+  assemble-check:
+    name: Assemble multi-arch packages
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+
+      - name: Download all native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: filesystem-mcp-native-*
+
+      - name: Assemble platform packages (fail-closed)
+        run: bun scripts/assemble-multiarch-natives.ts
+
+      - name: List assembled packages
+        run: |
+          set -euo pipefail
+          for dir in npm/*/; do
+            echo "== $dir =="
+            ls -la "$dir"
+            test -x "${dir}filesystem-mcp-server"
+            file "${dir}filesystem-mcp-server" || true
+          done
+
+      - name: Arch-aware wrapper smoke (host linux x64)
+        run: |
+          set -euo pipefail
+          chmod +x bin/filesystem-mcp
+          # Stage host binary into bin/native from linux-x64 package for local path smoke
+          mkdir -p bin/native
+          cp npm/linux-x64-gnu/filesystem-mcp-server bin/native/
+          chmod +x bin/native/filesystem-mcp-server
+          # Wrapper should resolve staged native
+          timeout 3s bin/filesystem-mcp doctor >/tmp/filesystem-help.txt 2>&1 || true
+          # Ensure we did not print "not built" when binary is present
+          if grep -qi 'is not built' /tmp/filesystem-help.txt; then
+            echo "FAIL: missing-native path detected despite staged binary"
+            cat /tmp/filesystem-help.txt
+            exit 1
+          fi
+          test -x npm/linux-x64-gnu/filesystem-mcp-server
+          echo "PASS: multi-arch assemble + wrapper smoke"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,81 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
+  # Multi-arch native matrix (GitHub-hosted). Fail-closed: all targets required
+  # before the publish job can assemble optionalDependency packages.
+  build-natives:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          # Both Darwin targets on macos-latest; x86_64 is cross-compiled.
+          # macos-13 Intel runners often queue indefinitely.
+          - host: macos-latest
+            target: aarch64-apple-darwin
+          - host: macos-latest
+            target: x86_64-apple-darwin
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+
+    name: Native ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: release-native-${{ matrix.settings.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            release-native-${{ matrix.settings.target }}-
+
+      - name: Build release natives
+        run: |
+          set -euo pipefail
+          cargo build --release -p filesystem-mcp-server --target ${{ matrix.settings.target }}
+          BIN="target/${{ matrix.settings.target }}/release/filesystem-mcp-server"
+          test -f "$BIN"
+          chmod +x "$BIN"
+          file "$BIN" || true
+          test "$(wc -c < "$BIN")" -gt 100000
+          mkdir -p native-out
+          cp "$BIN" native-out/filesystem-mcp-server
+          chmod +x native-out/filesystem-mcp-server
+
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: filesystem-mcp-native-${{ matrix.settings.target }}
+          path: native-out/filesystem-mcp-server
+          if-no-files-found: error
+          retention-days: 7
+
   release:
     name: Release
+    needs: build-natives
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -26,19 +92,68 @@ jobs:
         with:
           bun-version: '1.3.12'
 
+      - name: Set up Node.js (npm registry auth)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+        env:
+          # optionalDependencies platform packages may 404 until first multi-arch publish
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Build Rust core and MCP server
+      - name: Download multi-arch native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: filesystem-mcp-native-*
+
+      - name: Build TypeScript package
+        run: bun run build
+
+      - name: Build host Rust (release gate + cli probes)
         run: bun run build:rust
+
+      - name: Assemble multi-arch platform packages
+        run: |
+          set -euo pipefail
+          echo "== multi-arch artifacts =="
+          ls -laR artifacts || true
+          bun scripts/assemble-multiarch-natives.ts
+
+          # Stage linux x64 into bin/native as a documented linux fallback.
+          # Primary consumer path is optionalDependencies; arch-aware bin rejects wrong arch.
+          mkdir -p bin/native
+          if [ -f npm/linux-x64-gnu/filesystem-mcp-server ]; then
+            cp npm/linux-x64-gnu/filesystem-mcp-server bin/native/filesystem-mcp-server
+            chmod +x bin/native/filesystem-mcp-server
+          fi
+
+          chmod +x bin/filesystem-mcp
+          test -x bin/filesystem-mcp
+          head -n 8 bin/filesystem-mcp
+
+          # Fail-closed: every platform package must contain a runnable binary
+          for dir in npm/*/; do
+            test -f "${dir}package.json"
+            test -x "${dir}filesystem-mcp-server"
+            test "$(wc -c < "${dir}filesystem-mcp-server")" -gt 100000
+            echo "OK $(basename "$dir") $(wc -c < "${dir}filesystem-mcp-server") bytes"
+            file "${dir}filesystem-mcp-server" || true
+          done
+
+          bun scripts/sync-platform-versions.ts
 
       - name: Release gate
         run: bun run benchmark:release-gate
 
       - name: Create release PR or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           version: bun run version-packages
@@ -49,3 +164,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Multi-arch npm readback
+        if: always()
+        run: bun scripts/verify-multiarch-readback.ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ bin/native/*
 # differential harness scratch
 test/fixtures/differential-scratch*/
 /tmp/
+
+# Multi-arch assembled native binaries (built in CI or via bun run build:rust)
+npm/*/filesystem-mcp-server
+artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.1
+
+### Patch Changes
+
+- Ship multi-arch native MCP binaries via optionalDependencies platform packages (darwin-arm64, darwin-x64, linux-x64-gnu, linux-arm64-gnu). Arch-aware bin wrapper fails closed on wrong-arch or missing native; TypeScript transport remains explicit opt-in.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/__tests__/engine/rustMcp.boundary.test.ts
+++ b/__tests__/engine/rustMcp.boundary.test.ts
@@ -21,9 +21,13 @@ describe('MCP transport boundary', () => {
 		expect(script).toContain('filesystem-mcp-server')
 		expect(script).toContain('resolve_rust_bin')
 		expect(script).toContain('use_ts_transport')
-		const tail = execSync(`grep -v '^#' "${binWrapper}" | tail -n 8`, { encoding: 'utf8' })
-		expect(tail).toContain('exec "$bin"')
-		expect(tail).not.toMatch(/^\s*exec node "\$TS_ENTRY"/m)
+		// Default path execs the resolved native bin; TS is only via use_ts_transport opt-in.
+		expect(script).toContain('exec "$bin"')
+		expect(script).toMatch(/if bin="\$\(resolve_rust_bin\)"; then[\s\S]*exec "\$bin"/)
+		// Arch-aware resolution (optionalDependencies) must be present for multi-arch npm.
+		expect(script).toContain('resolve_from_optional_dep')
+		expect(script).toContain('is_runnable_native')
+		expect(script).toContain('@sylphx/filesystem-mcp-darwin-arm64')
 	})
 
 	it('executes the shipped default bin path through the Rust rmcp server', () => {

--- a/bin/filesystem-mcp
+++ b/bin/filesystem-mcp
@@ -1,12 +1,124 @@
 #!/usr/bin/env bash
+# Filesystem MCP launcher — default Rust rmcp; TypeScript transport is explicit opt-in.
+# Resolves platform-matched native via optionalDependencies, staged bin/native, or local cargo target.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TS_ENTRY="$ROOT/dist/index.js"
 
+host_platform_key() {
+	local os arch
+	os="$(uname -s 2>/dev/null || echo unknown)"
+	arch="$(uname -m 2>/dev/null || echo unknown)"
+	case "$os" in
+		Darwin) os="darwin" ;;
+		Linux) os="linux" ;;
+		MINGW*|MSYS*|CYGWIN*|Windows_NT) os="win32" ;;
+		*) os="$(printf '%s' "$os" | tr '[:upper:]' '[:lower:]')" ;;
+	esac
+	case "$arch" in
+		x86_64|amd64) arch="x64" ;;
+		aarch64|arm64) arch="arm64" ;;
+		armv7l) arch="arm" ;;
+		i386|i686) arch="ia32" ;;
+	esac
+	printf '%s-%s\n' "$os" "$arch"
+}
+
+platform_package_name() {
+	case "$(host_platform_key)" in
+		darwin-arm64) printf '%s\n' '@sylphx/filesystem-mcp-darwin-arm64' ;;
+		darwin-x64) printf '%s\n' '@sylphx/filesystem-mcp-darwin-x64' ;;
+		linux-x64) printf '%s\n' '@sylphx/filesystem-mcp-linux-x64-gnu' ;;
+		linux-arm64) printf '%s\n' '@sylphx/filesystem-mcp-linux-arm64-gnu' ;;
+		*) return 1 ;;
+	esac
+}
+
+# Prefer a path only when it is executable *and* matches this host's binary format
+# (avoids treating a wrong-arch ELF as "present" then hard-failing at exec).
+is_runnable_native() {
+	local candidate="$1"
+	[[ -n "$candidate" && -f "$candidate" && -x "$candidate" ]] || return 1
+
+	if command -v file >/dev/null 2>&1; then
+		local info
+		info="$(file -b "$candidate" 2>/dev/null || true)"
+		case "$(host_platform_key)" in
+			darwin-arm64)
+				[[ "$info" == *"Mach-O"* && ( "$info" == *"arm64"* || "$info" == *"aarch64"* ) ]] || return 1
+				;;
+			darwin-x64)
+				[[ "$info" == *"Mach-O"* && ( "$info" == *"x86_64"* || "$info" == *"x86-64"* ) ]] || return 1
+				;;
+			linux-x64)
+				[[ "$info" == *"ELF"* && ( "$info" == *"x86-64"* || "$info" == *"x86_64"* ) ]] || return 1
+				;;
+			linux-arm64)
+				[[ "$info" == *"ELF"* && ( "$info" == *"aarch64"* || "$info" == *"ARM aarch64"* || "$info" == *"arm64"* ) ]] || return 1
+				;;
+		esac
+	fi
+	return 0
+}
+
+resolve_from_optional_dep() {
+	local pkg_name pkg_dir candidate
+	pkg_name="$(platform_package_name 2>/dev/null || true)"
+	[[ -n "$pkg_name" ]] || return 1
+
+	local search_roots=(
+		"$ROOT/node_modules"
+		"$ROOT/../node_modules"
+		"$ROOT/../../node_modules"
+		"$ROOT/../../../node_modules"
+	)
+
+	for root in "${search_roots[@]}"; do
+		pkg_dir="$root/$pkg_name"
+		candidate="$pkg_dir/filesystem-mcp-server"
+		if is_runnable_native "$candidate"; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+
+	if command -v node >/dev/null 2>&1; then
+		candidate="$(
+			node -e "
+        try {
+          const p = require('node:path');
+          const { createRequire } = require('node:module');
+          const r = createRequire(p.join('$ROOT', 'package.json'));
+          const pkg = r.resolve('$pkg_name/package.json');
+          process.stdout.write(p.join(p.dirname(pkg), 'filesystem-mcp-server'));
+        } catch {
+          process.exit(1);
+        }
+      " 2>/dev/null || true
+		)"
+		if is_runnable_native "${candidate:-}"; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
 resolve_rust_bin() {
-	if [[ -n "${FILESYSTEM_MCP_RUST_BIN:-}" && -x "${FILESYSTEM_MCP_RUST_BIN}" ]]; then
-		printf '%s\n' "${FILESYSTEM_MCP_RUST_BIN}"
+	if [[ -n "${FILESYSTEM_MCP_RUST_BIN:-}" ]]; then
+		if is_runnable_native "${FILESYSTEM_MCP_RUST_BIN}"; then
+			printf '%s\n' "${FILESYSTEM_MCP_RUST_BIN}"
+			return 0
+		fi
+		echo "[filesystem-mcp] FILESYSTEM_MCP_RUST_BIN is set but not a runnable native for $(host_platform_key): ${FILESYSTEM_MCP_RUST_BIN}" >&2
+		return 1
+	fi
+
+	local candidate
+	if candidate="$(resolve_from_optional_dep)"; then
+		printf '%s\n' "$candidate"
 		return 0
 	fi
 
@@ -14,7 +126,7 @@ resolve_rust_bin() {
 		"$ROOT/bin/native/filesystem-mcp-server" \
 		"$ROOT/target/release/filesystem-mcp-server" \
 		"$ROOT/target/debug/filesystem-mcp-server"; do
-		if [[ -x "$candidate" ]]; then
+		if is_runnable_native "$candidate"; then
 			printf '%s\n' "$candidate"
 			return 0
 		fi
@@ -38,5 +150,14 @@ if bin="$(resolve_rust_bin)"; then
 	exec "$bin" "$@"
 fi
 
-echo "[filesystem-mcp] Rust MCP server (rmcp) is not built. Run: bun run build:rust" >&2
+host="$(host_platform_key)"
+pkg="$(platform_package_name 2>/dev/null || true)"
+echo "[filesystem-mcp] No runnable Rust MCP server (rmcp) for host platform: ${host}" >&2
+if [[ -n "${pkg:-}" ]]; then
+	echo "[filesystem-mcp] Expected optionalDependency package: ${pkg} (filesystem-mcp-server binary)." >&2
+	echo "[filesystem-mcp] Reinstall with optional deps enabled, or run: bun run build:rust" >&2
+else
+	echo "[filesystem-mcp] Unsupported platform for published natives. Supported: darwin-arm64, darwin-x64, linux-x64, linux-arm64." >&2
+	echo "[filesystem-mcp] Build from source: bun run build:rust" >&2
+fi
 exit 1

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,12 @@
         "vitepress": "^1.6.3",
         "vitest": "^3.1.1",
       },
+      "optionalDependencies": {
+        "@sylphx/filesystem-mcp-darwin-arm64": "0.7.0",
+        "@sylphx/filesystem-mcp-darwin-x64": "0.7.0",
+        "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.0",
+        "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.0",
+      },
     },
   },
   "packages": {

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "@sylphx/filesystem-mcp-darwin-arm64",
-  "version": "0.7.1",
-  "description": "Filesystem MCP server native binary for darwin-arm64",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "files": [
-    "filesystem-mcp-server"
-  ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
-    "directory": "npm/darwin-arm64"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
+	"name": "@sylphx/filesystem-mcp-darwin-arm64",
+	"version": "0.7.1",
+	"description": "Filesystem MCP server native binary for darwin-arm64",
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"files": [
+		"filesystem-mcp-server"
+	],
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/SylphxAI/filesystem-mcp.git",
+		"directory": "npm/darwin-arm64"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sylphx/filesystem-mcp-darwin-arm64",
+  "version": "0.7.1",
+  "description": "Filesystem MCP server native binary for darwin-arm64",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "filesystem-mcp-server"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
+    "directory": "npm/darwin-arm64"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "@sylphx/filesystem-mcp-darwin-x64",
-  "version": "0.7.1",
-  "description": "Filesystem MCP server native binary for darwin-x64",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "files": [
-    "filesystem-mcp-server"
-  ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
-    "directory": "npm/darwin-x64"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
+	"name": "@sylphx/filesystem-mcp-darwin-x64",
+	"version": "0.7.1",
+	"description": "Filesystem MCP server native binary for darwin-x64",
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"x64"
+	],
+	"files": [
+		"filesystem-mcp-server"
+	],
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/SylphxAI/filesystem-mcp.git",
+		"directory": "npm/darwin-x64"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
 }

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sylphx/filesystem-mcp-darwin-x64",
+  "version": "0.7.1",
+  "description": "Filesystem MCP server native binary for darwin-x64",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "filesystem-mcp-server"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
+    "directory": "npm/darwin-x64"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "@sylphx/filesystem-mcp-linux-arm64-gnu",
-  "version": "0.7.1",
-  "description": "Filesystem MCP server native binary for linux-arm64-gnu",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "libc": [
-    "glibc"
-  ],
-  "files": [
-    "filesystem-mcp-server"
-  ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
-    "directory": "npm/linux-arm64-gnu"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
+	"name": "@sylphx/filesystem-mcp-linux-arm64-gnu",
+	"version": "0.7.1",
+	"description": "Filesystem MCP server native binary for linux-arm64-gnu",
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"libc": [
+		"glibc"
+	],
+	"files": [
+		"filesystem-mcp-server"
+	],
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/SylphxAI/filesystem-mcp.git",
+		"directory": "npm/linux-arm64-gnu"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
 }

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sylphx/filesystem-mcp-linux-arm64-gnu",
+  "version": "0.7.1",
+  "description": "Filesystem MCP server native binary for linux-arm64-gnu",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "files": [
+    "filesystem-mcp-server"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
+    "directory": "npm/linux-arm64-gnu"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sylphx/filesystem-mcp-linux-x64-gnu",
+  "version": "0.7.1",
+  "description": "Filesystem MCP server native binary for linux-x64-gnu",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "files": [
+    "filesystem-mcp-server"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
+    "directory": "npm/linux-x64-gnu"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "@sylphx/filesystem-mcp-linux-x64-gnu",
-  "version": "0.7.1",
-  "description": "Filesystem MCP server native binary for linux-x64-gnu",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "libc": [
-    "glibc"
-  ],
-  "files": [
-    "filesystem-mcp-server"
-  ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SylphxAI/filesystem-mcp.git",
-    "directory": "npm/linux-x64-gnu"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
+	"name": "@sylphx/filesystem-mcp-linux-x64-gnu",
+	"version": "0.7.1",
+	"description": "Filesystem MCP server native binary for linux-x64-gnu",
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"x64"
+	],
+	"libc": [
+		"glibc"
+	],
+	"files": [
+		"filesystem-mcp-server"
+	],
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/SylphxAI/filesystem-mcp.git",
+		"directory": "npm/linux-x64-gnu"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,117 +1,127 @@
 {
-	"name": "@sylphx/filesystem-mcp",
-	"version": "0.7.0",
-	"description": "An MCP server providing filesystem tools relative to a project root.",
-	"type": "module",
-	"main": "./dist/index.js",
-	"module": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"bin": {
-		"filesystem-mcp": "./bin/filesystem-mcp"
-	},
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"files": [
-		"bin/",
-		"dist/",
-		"README.md",
-		"LICENSE"
-	],
-	"engines": {
-		"node": "22.14"
-	},
-	"scripts": {
-		"build": "bunx bunup && bun build src/legacy-engine-runtime.ts --outdir dist --target node",
-		"build:rust": "cargo build --release -p filesystem-core -p filesystem-cli -p filesystem-mcp-server && bun scripts/stage-rust-mcp.ts",
-		"watch": "tsc --watch",
-		"inspector": "npx @modelcontextprotocol/inspector dist/index.js",
-		"test": "vitest run",
-		"test:watch": "vitest watch",
-		"test:cov": "vitest run --coverage --reporter=junit --outputFile=test-report.junit.xml --exclude __tests__/release-gate.test.ts",
-		"lint": "biome check .",
-		"lint:fix": "biome check --write .",
-		"format": "biome format --write .",
-		"check-format": "biome format .",
-		"validate": "biome check . && bun run typecheck && bun run test",
-		"docs:dev": "vitepress dev docs",
-		"docs:build": "bun run docs:api && vitepress build docs",
-		"docs:preview": "vitepress preview docs",
-		"start": "node dist/index.js",
-		"typecheck": "tsc --noEmit",
-		"benchmark": "vitest bench --run",
-		"doctor": "bun run src/index.ts doctor",
-		"benchmark:release-gate": "bun scripts/release-gate.ts",
-		"audit:shipped": "bun scripts/audit-shipped-deps.ts",
-		"test:rust-policy": "cargo test && vitest run __tests__/engine/rust-policy.boundary.test.ts",
-		"test:rust-walk": "cargo test && vitest run __tests__/engine/rust-walk.boundary.test.ts",
-		"test:rust-audit": "cargo test && vitest run __tests__/engine/rust-audit.boundary.test.ts",
-		"clean": "rimraf dist coverage",
-		"docs:api": "node scripts/generate-api-docs.mjs",
-		"prepublishOnly": "bun run clean && bun run build && bun run build:rust",
-		"changeset": "changeset",
-		"changeset:version": "changeset version",
-		"changeset:publish": "changeset publish",
-		"version-packages": "changeset version",
-		"release": "bun run build && bun run build:rust && bun run benchmark:release-gate && changeset publish"
-	},
-	"homepage": "https://github.com/SylphxAI/filesystem-mcp#readme",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/SylphxAI/filesystem-mcp.git"
-	},
-	"keywords": [
-		"mcp",
-		"model-context-protocol",
-		"filesystem",
-		"file",
-		"directory",
-		"typescript",
-		"node",
-		"cli",
-		"ai",
-		"agent",
-		"tool"
-	],
-	"author": "Sylphx <hi@sylphx.com> (https://sylphx.com)",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/SylphxAI/filesystem-mcp/issues"
-	},
-	"publishConfig": {
-		"access": "public"
-	},
-	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.20.2",
-		"glob": "^11.0.1",
-		"zod": "^3.25.76",
-		"zod-to-json-schema": "^3.24.5"
-	},
-	"devDependencies": {
-		"@changesets/cli": "^2.28.1",
-		"@commitlint/cli": "^19.8.0",
-		"@commitlint/config-conventional": "^19.8.0",
-		"@biomejs/biome": "^2.3.12",
-		"@sylphx/biome-config": "^0.4.1",
-		"@sylphx/tsconfig": "^0.3.1",
-		"@types/glob": "^8.1.0",
-		"@types/node": "^24.9.1",
-		"@types/uuid": "^10.0.0",
-		"@vitest/coverage-v8": "^3.1.1",
-		"rimraf": "^6.0.1",
-		"typedoc": "^0.28.14",
-		"typedoc-plugin-markdown": "^4.6.2",
-		"typescript": "^7.0.2",
-		"uuid": "^11.1.0",
-		"vitepress": "^1.6.3",
-		"vitest": "^3.1.1"
-	},
-	"lint-staged": {
-		"*.{ts,tsx,js,cjs,mjs,json,md,yaml,yml,html,css}": "biome check --write --no-errors-on-unmatched"
-	},
-	"packageManager": "bun@1.3.12"
+  "name": "@sylphx/filesystem-mcp",
+  "version": "0.7.1",
+  "description": "An MCP server providing filesystem tools relative to a project root.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "filesystem-mcp": "./bin/filesystem-mcp"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": "22.14"
+  },
+  "scripts": {
+    "build": "bunx bunup && bun build src/legacy-engine-runtime.ts --outdir dist --target node",
+    "build:rust": "cargo build --release -p filesystem-core -p filesystem-cli -p filesystem-mcp-server && bun scripts/stage-rust-mcp.ts",
+    "watch": "tsc --watch",
+    "inspector": "npx @modelcontextprotocol/inspector dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:cov": "vitest run --coverage --reporter=junit --outputFile=test-report.junit.xml --exclude __tests__/release-gate.test.ts",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "check-format": "biome format .",
+    "validate": "biome check . && bun run typecheck && bun run test",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "bun run docs:api && vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "benchmark": "vitest bench --run",
+    "doctor": "bun run src/index.ts doctor",
+    "benchmark:release-gate": "bun scripts/release-gate.ts",
+    "audit:shipped": "bun scripts/audit-shipped-deps.ts",
+    "test:rust-policy": "cargo test && vitest run __tests__/engine/rust-policy.boundary.test.ts",
+    "test:rust-walk": "cargo test && vitest run __tests__/engine/rust-walk.boundary.test.ts",
+    "test:rust-audit": "cargo test && vitest run __tests__/engine/rust-audit.boundary.test.ts",
+    "clean": "rimraf dist coverage",
+    "docs:api": "node scripts/generate-api-docs.mjs",
+    "prepublishOnly": "bun run clean && bun run build",
+    "changeset": "changeset",
+    "changeset:version": "changeset version && bun scripts/sync-platform-versions.ts",
+    "changeset:publish": "bun scripts/sync-platform-versions.ts && bun scripts/publish-platform-packages.ts && changeset publish",
+    "version-packages": "changeset version && bun scripts/sync-platform-versions.ts",
+    "release": "bun scripts/sync-platform-versions.ts && bun scripts/publish-platform-packages.ts && changeset publish",
+    "assemble:multiarch": "bun scripts/assemble-multiarch-natives.ts",
+    "sync:platform-versions": "bun scripts/sync-platform-versions.ts",
+    "verify:multiarch-readback": "bun scripts/verify-multiarch-readback.ts"
+  },
+  "homepage": "https://github.com/SylphxAI/filesystem-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SylphxAI/filesystem-mcp.git"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "filesystem",
+    "file",
+    "directory",
+    "typescript",
+    "node",
+    "cli",
+    "ai",
+    "agent",
+    "tool"
+  ],
+  "author": "Sylphx <hi@sylphx.com> (https://sylphx.com)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/SylphxAI/filesystem-mcp/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.20.2",
+    "glob": "^11.0.1",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.24.5"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.28.1",
+    "@commitlint/cli": "^19.8.0",
+    "@commitlint/config-conventional": "^19.8.0",
+    "@biomejs/biome": "^2.3.12",
+    "@sylphx/biome-config": "^0.4.1",
+    "@sylphx/tsconfig": "^0.3.1",
+    "@types/glob": "^8.1.0",
+    "@types/node": "^24.9.1",
+    "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^3.1.1",
+    "rimraf": "^6.0.1",
+    "typedoc": "^0.28.14",
+    "typedoc-plugin-markdown": "^4.6.2",
+    "typescript": "^7.0.2",
+    "uuid": "^11.1.0",
+    "vitepress": "^1.6.3",
+    "vitest": "^3.1.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,cjs,mjs,json,md,yaml,yml,html,css}": "biome check --write --no-errors-on-unmatched"
+  },
+  "packageManager": "bun@1.3.12",
+  "optionalDependencies": {
+    "@sylphx/filesystem-mcp-darwin-arm64": "0.7.1",
+    "@sylphx/filesystem-mcp-darwin-x64": "0.7.1",
+    "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.1",
+    "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,127 +1,127 @@
 {
-  "name": "@sylphx/filesystem-mcp",
-  "version": "0.7.1",
-  "description": "An MCP server providing filesystem tools relative to a project root.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "bin": {
-    "filesystem-mcp": "./bin/filesystem-mcp"
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "bin/",
-    "dist/",
-    "README.md",
-    "LICENSE"
-  ],
-  "engines": {
-    "node": "22.14"
-  },
-  "scripts": {
-    "build": "bunx bunup && bun build src/legacy-engine-runtime.ts --outdir dist --target node",
-    "build:rust": "cargo build --release -p filesystem-core -p filesystem-cli -p filesystem-mcp-server && bun scripts/stage-rust-mcp.ts",
-    "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector dist/index.js",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "test:cov": "vitest run --coverage --reporter=junit --outputFile=test-report.junit.xml --exclude __tests__/release-gate.test.ts",
-    "lint": "biome check .",
-    "lint:fix": "biome check --write .",
-    "format": "biome format --write .",
-    "check-format": "biome format .",
-    "validate": "biome check . && bun run typecheck && bun run test",
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "bun run docs:api && vitepress build docs",
-    "docs:preview": "vitepress preview docs",
-    "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit",
-    "benchmark": "vitest bench --run",
-    "doctor": "bun run src/index.ts doctor",
-    "benchmark:release-gate": "bun scripts/release-gate.ts",
-    "audit:shipped": "bun scripts/audit-shipped-deps.ts",
-    "test:rust-policy": "cargo test && vitest run __tests__/engine/rust-policy.boundary.test.ts",
-    "test:rust-walk": "cargo test && vitest run __tests__/engine/rust-walk.boundary.test.ts",
-    "test:rust-audit": "cargo test && vitest run __tests__/engine/rust-audit.boundary.test.ts",
-    "clean": "rimraf dist coverage",
-    "docs:api": "node scripts/generate-api-docs.mjs",
-    "prepublishOnly": "bun run clean && bun run build",
-    "changeset": "changeset",
-    "changeset:version": "changeset version && bun scripts/sync-platform-versions.ts",
-    "changeset:publish": "bun scripts/sync-platform-versions.ts && bun scripts/publish-platform-packages.ts && changeset publish",
-    "version-packages": "changeset version && bun scripts/sync-platform-versions.ts",
-    "release": "bun scripts/sync-platform-versions.ts && bun scripts/publish-platform-packages.ts && changeset publish",
-    "assemble:multiarch": "bun scripts/assemble-multiarch-natives.ts",
-    "sync:platform-versions": "bun scripts/sync-platform-versions.ts",
-    "verify:multiarch-readback": "bun scripts/verify-multiarch-readback.ts"
-  },
-  "homepage": "https://github.com/SylphxAI/filesystem-mcp#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/SylphxAI/filesystem-mcp.git"
-  },
-  "keywords": [
-    "mcp",
-    "model-context-protocol",
-    "filesystem",
-    "file",
-    "directory",
-    "typescript",
-    "node",
-    "cli",
-    "ai",
-    "agent",
-    "tool"
-  ],
-  "author": "Sylphx <hi@sylphx.com> (https://sylphx.com)",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/SylphxAI/filesystem-mcp/issues"
-  },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.20.2",
-    "glob": "^11.0.1",
-    "zod": "^3.25.76",
-    "zod-to-json-schema": "^3.24.5"
-  },
-  "devDependencies": {
-    "@changesets/cli": "^2.28.1",
-    "@commitlint/cli": "^19.8.0",
-    "@commitlint/config-conventional": "^19.8.0",
-    "@biomejs/biome": "^2.3.12",
-    "@sylphx/biome-config": "^0.4.1",
-    "@sylphx/tsconfig": "^0.3.1",
-    "@types/glob": "^8.1.0",
-    "@types/node": "^24.9.1",
-    "@types/uuid": "^10.0.0",
-    "@vitest/coverage-v8": "^3.1.1",
-    "rimraf": "^6.0.1",
-    "typedoc": "^0.28.14",
-    "typedoc-plugin-markdown": "^4.6.2",
-    "typescript": "^7.0.2",
-    "uuid": "^11.1.0",
-    "vitepress": "^1.6.3",
-    "vitest": "^3.1.1"
-  },
-  "lint-staged": {
-    "*.{ts,tsx,js,cjs,mjs,json,md,yaml,yml,html,css}": "biome check --write --no-errors-on-unmatched"
-  },
-  "packageManager": "bun@1.3.12",
-  "optionalDependencies": {
-    "@sylphx/filesystem-mcp-darwin-arm64": "0.7.1",
-    "@sylphx/filesystem-mcp-darwin-x64": "0.7.1",
-    "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.1",
-    "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.1"
-  }
+	"name": "@sylphx/filesystem-mcp",
+	"version": "0.7.1",
+	"description": "An MCP server providing filesystem tools relative to a project root.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"filesystem-mcp": "./bin/filesystem-mcp"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"bin/",
+		"dist/",
+		"README.md",
+		"LICENSE"
+	],
+	"engines": {
+		"node": "22.14"
+	},
+	"scripts": {
+		"build": "bunx bunup && bun build src/legacy-engine-runtime.ts --outdir dist --target node",
+		"build:rust": "cargo build --release -p filesystem-core -p filesystem-cli -p filesystem-mcp-server && bun scripts/stage-rust-mcp.ts",
+		"watch": "tsc --watch",
+		"inspector": "npx @modelcontextprotocol/inspector dist/index.js",
+		"test": "vitest run",
+		"test:watch": "vitest watch",
+		"test:cov": "vitest run --coverage --reporter=junit --outputFile=test-report.junit.xml --exclude __tests__/release-gate.test.ts",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"format": "biome format --write .",
+		"check-format": "biome format .",
+		"validate": "biome check . && bun run typecheck && bun run test",
+		"docs:dev": "vitepress dev docs",
+		"docs:build": "bun run docs:api && vitepress build docs",
+		"docs:preview": "vitepress preview docs",
+		"start": "node dist/index.js",
+		"typecheck": "tsc --noEmit",
+		"benchmark": "vitest bench --run",
+		"doctor": "bun run src/index.ts doctor",
+		"benchmark:release-gate": "bun scripts/release-gate.ts",
+		"audit:shipped": "bun scripts/audit-shipped-deps.ts",
+		"test:rust-policy": "cargo test && vitest run __tests__/engine/rust-policy.boundary.test.ts",
+		"test:rust-walk": "cargo test && vitest run __tests__/engine/rust-walk.boundary.test.ts",
+		"test:rust-audit": "cargo test && vitest run __tests__/engine/rust-audit.boundary.test.ts",
+		"clean": "rimraf dist coverage",
+		"docs:api": "node scripts/generate-api-docs.mjs",
+		"prepublishOnly": "bun run clean && bun run build",
+		"changeset": "changeset",
+		"changeset:version": "changeset version && bun scripts/sync-platform-versions.ts",
+		"changeset:publish": "bun scripts/sync-platform-versions.ts && bun scripts/publish-platform-packages.ts && changeset publish",
+		"version-packages": "changeset version && bun scripts/sync-platform-versions.ts",
+		"release": "bun scripts/sync-platform-versions.ts && bun scripts/publish-platform-packages.ts && changeset publish",
+		"assemble:multiarch": "bun scripts/assemble-multiarch-natives.ts",
+		"sync:platform-versions": "bun scripts/sync-platform-versions.ts",
+		"verify:multiarch-readback": "bun scripts/verify-multiarch-readback.ts"
+	},
+	"homepage": "https://github.com/SylphxAI/filesystem-mcp#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/SylphxAI/filesystem-mcp.git"
+	},
+	"keywords": [
+		"mcp",
+		"model-context-protocol",
+		"filesystem",
+		"file",
+		"directory",
+		"typescript",
+		"node",
+		"cli",
+		"ai",
+		"agent",
+		"tool"
+	],
+	"author": "Sylphx <hi@sylphx.com> (https://sylphx.com)",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/SylphxAI/filesystem-mcp/issues"
+	},
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org"
+	},
+	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.20.2",
+		"glob": "^11.0.1",
+		"zod": "^3.25.76",
+		"zod-to-json-schema": "^3.24.5"
+	},
+	"devDependencies": {
+		"@changesets/cli": "^2.28.1",
+		"@commitlint/cli": "^19.8.0",
+		"@commitlint/config-conventional": "^19.8.0",
+		"@biomejs/biome": "^2.3.12",
+		"@sylphx/biome-config": "^0.4.1",
+		"@sylphx/tsconfig": "^0.3.1",
+		"@types/glob": "^8.1.0",
+		"@types/node": "^24.9.1",
+		"@types/uuid": "^10.0.0",
+		"@vitest/coverage-v8": "^3.1.1",
+		"rimraf": "^6.0.1",
+		"typedoc": "^0.28.14",
+		"typedoc-plugin-markdown": "^4.6.2",
+		"typescript": "^7.0.2",
+		"uuid": "^11.1.0",
+		"vitepress": "^1.6.3",
+		"vitest": "^3.1.1"
+	},
+	"lint-staged": {
+		"*.{ts,tsx,js,cjs,mjs,json,md,yaml,yml,html,css}": "biome check --write --no-errors-on-unmatched"
+	},
+	"packageManager": "bun@1.3.12",
+	"optionalDependencies": {
+		"@sylphx/filesystem-mcp-darwin-arm64": "0.7.1",
+		"@sylphx/filesystem-mcp-darwin-x64": "0.7.1",
+		"@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.1",
+		"@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.1"
+	}
 }

--- a/scripts/assemble-multiarch-natives.ts
+++ b/scripts/assemble-multiarch-natives.ts
@@ -1,0 +1,138 @@
+/**
+ * Assemble multi-arch platform packages from CI artifacts (or local staging).
+ *
+ * Expected artifact layout (from native matrix upload):
+ *   artifacts/filesystem-mcp-native-<rust-target>/filesystem-mcp-server
+ *
+ * Writes into:
+ *   npm/<platform-key>/filesystem-mcp-server
+ *
+ * Fail-closed: requires all configured platforms unless FILESYSTEM_MCP_MULTIARCH_PARTIAL=1.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+
+const PLATFORMS = [
+	{
+		key: 'darwin-arm64',
+		target: 'aarch64-apple-darwin',
+		artifactNames: ['filesystem-mcp-native-aarch64-apple-darwin'],
+	},
+	{
+		key: 'darwin-x64',
+		target: 'x86_64-apple-darwin',
+		artifactNames: ['filesystem-mcp-native-x86_64-apple-darwin'],
+	},
+	{
+		key: 'linux-x64-gnu',
+		target: 'x86_64-unknown-linux-gnu',
+		artifactNames: ['filesystem-mcp-native-x86_64-unknown-linux-gnu'],
+	},
+	{
+		key: 'linux-arm64-gnu',
+		target: 'aarch64-unknown-linux-gnu',
+		artifactNames: ['filesystem-mcp-native-aarch64-unknown-linux-gnu'],
+	},
+] as const
+
+const artifactsRoot = process.env.FILESYSTEM_MCP_ARTIFACTS_DIR
+	? path.resolve(process.env.FILESYSTEM_MCP_ARTIFACTS_DIR)
+	: path.join(repoRoot, 'artifacts')
+
+const partial = process.env.FILESYSTEM_MCP_MULTIARCH_PARTIAL === '1'
+const binaryName = 'filesystem-mcp-server'
+
+function findBinary(artifactDirNames: readonly string[]): string | null {
+	for (const name of artifactDirNames) {
+		const candidates = [
+			path.join(artifactsRoot, name, binaryName),
+			path.join(artifactsRoot, name, binaryName.replace(/-/g, '_')),
+			// download-artifact sometimes flattens one level
+			path.join(artifactsRoot, binaryName),
+		]
+		for (const candidate of candidates) {
+			if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+				return candidate
+			}
+		}
+		// Walk artifact dir for the binary name
+		const dir = path.join(artifactsRoot, name)
+		if (!fs.existsSync(dir)) continue
+		const stack = [dir]
+		while (stack.length > 0) {
+			const current = stack.pop()
+			if (current === undefined) break
+			for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+				const full = path.join(current, entry.name)
+				if (entry.isDirectory()) {
+					stack.push(full)
+				} else if (entry.name === binaryName) {
+					return full
+				}
+			}
+		}
+	}
+	return null
+}
+
+const missing: string[] = []
+let assembled = 0
+
+for (const platform of PLATFORMS) {
+	const source = findBinary(platform.artifactNames)
+	const destDir = path.join(repoRoot, 'npm', platform.key)
+	const dest = path.join(destDir, binaryName)
+
+	if (!source) {
+		missing.push(`${platform.key} (${platform.target})`)
+		console.error(`[assemble-multiarch] MISSING binary for ${platform.key}`)
+		continue
+	}
+
+	fs.mkdirSync(destDir, { recursive: true })
+	fs.copyFileSync(source, dest)
+	fs.chmodSync(dest, 0o755)
+
+	const size = fs.statSync(dest).size
+	if (size < 1024 * 100) {
+		console.error(`[assemble-multiarch] FAIL: ${dest} is suspiciously small (${size} bytes)`)
+		process.exit(1)
+	}
+
+	console.log(`[assemble-multiarch] ${platform.key}: ${source} → ${dest} (${size} bytes)`)
+	assembled++
+}
+
+if (missing.length > 0) {
+	console.error(`[assemble-multiarch] Missing platforms: ${missing.join(', ')}`)
+	console.error(`[assemble-multiarch] artifactsRoot=${artifactsRoot}`)
+	if (fs.existsSync(artifactsRoot)) {
+		console.error('[assemble-multiarch] artifacts listing:')
+		const list = (dir: string, depth = 0) => {
+			if (depth > 3) return
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const full = path.join(dir, entry.name)
+				console.error(`${'  '.repeat(depth)}${entry.isDirectory() ? `${entry.name}/` : entry.name}`)
+				if (entry.isDirectory()) list(full, depth + 1)
+			}
+		}
+		list(artifactsRoot)
+	} else {
+		console.error('[assemble-multiarch] artifacts root does not exist')
+	}
+	if (!partial) {
+		console.error(
+			'[assemble-multiarch] Fail-closed: all platforms required. Set FILESYSTEM_MCP_MULTIARCH_PARTIAL=1 only for local debug.',
+		)
+		process.exit(1)
+	}
+}
+
+if (assembled === 0) {
+	console.error('[assemble-multiarch] No platform binaries assembled')
+	process.exit(1)
+}
+
+console.log(`[assemble-multiarch] Assembled ${assembled}/${PLATFORMS.length} platform packages`)

--- a/scripts/publish-platform-packages.ts
+++ b/scripts/publish-platform-packages.ts
@@ -49,7 +49,7 @@ function packageExists(name: string, version: string): boolean {
 
 	// Tarball HEAD fallback (packument lag)
 	const scopedPath = name.startsWith('@') ? name.replace('/', '%2f') : name
-	const shortName = name.includes('/') ? name.split('/')[1]! : name
+	const shortName = name.includes('/') ? (name.split('/')[1] ?? name) : name
 	const url = `https://registry.npmjs.org/${scopedPath}/-/${shortName}-${version}.tgz`
 	const head = spawnSync(
 		'curl',

--- a/scripts/publish-platform-packages.ts
+++ b/scripts/publish-platform-packages.ts
@@ -48,7 +48,8 @@ function packageExists(name: string, version: string): boolean {
 	}
 
 	// Tarball HEAD fallback (packument lag)
-	const scopedPath = name.startsWith('@') ? name.replace('/', '%2f') : name
+	// Encode every "/" for the npm registry path (scoped packages are @scope/name).
+	const scopedPath = name.startsWith('@') ? name.split('/').join('%2f') : name
 	const shortName = name.includes('/') ? (name.split('/')[1] ?? name) : name
 	const url = `https://registry.npmjs.org/${scopedPath}/-/${shortName}-${version}.tgz`
 	const head = spawnSync(

--- a/scripts/publish-platform-packages.ts
+++ b/scripts/publish-platform-packages.ts
@@ -1,0 +1,116 @@
+/**
+ * Publish multi-arch platform packages (optionalDependencies) to npm.
+ *
+ * Fail-closed: every npm/<platform>/ directory must contain package.json +
+ * a non-trivial executable filesystem-mcp-server binary.
+ *
+ * Intended to run after assemble-multiarch-natives + sync-platform-versions,
+ * and before `changeset publish` for the main package.
+ */
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+const platformRoot = path.join(repoRoot, 'npm')
+const binaryName = 'filesystem-mcp-server'
+const minBytes = 100_000
+
+if (!fs.existsSync(platformRoot)) {
+	console.error('[publish-platform-packages] npm/ directory missing')
+	process.exit(1)
+}
+
+const platforms = fs
+	.readdirSync(platformRoot, { withFileTypes: true })
+	.filter((e) => e.isDirectory())
+	.map((e) => e.name)
+	.sort()
+
+if (platforms.length === 0) {
+	console.error('[publish-platform-packages] No platform packages under npm/')
+	process.exit(1)
+}
+
+function packageExists(name: string, version: string): boolean {
+	const view = spawnSync('npm', ['view', `${name}@${version}`, 'version', '--json'], {
+		encoding: 'utf8',
+	})
+	if (view.status === 0) {
+		const raw = (view.stdout || '').trim()
+		try {
+			const parsed = JSON.parse(raw) as string | string[]
+			if (typeof parsed === 'string') return parsed === version
+			if (Array.isArray(parsed)) return parsed.includes(version)
+		} catch {
+			return raw.replace(/"/g, '') === version
+		}
+	}
+
+	// Tarball HEAD fallback (packument lag)
+	const scopedPath = name.startsWith('@') ? name.replace('/', '%2f') : name
+	const shortName = name.includes('/') ? name.split('/')[1]! : name
+	const url = `https://registry.npmjs.org/${scopedPath}/-/${shortName}-${version}.tgz`
+	const head = spawnSync(
+		'curl',
+		['-sS', '-o', '/dev/null', '-w', '%{http_code}', '-L', '-I', url],
+		{ encoding: 'utf8' },
+	)
+	return head.status === 0 && (head.stdout || '').trim().split('\n').pop() === '200'
+}
+
+let published = 0
+let skipped = 0
+
+for (const platform of platforms) {
+	const dir = path.join(platformRoot, platform)
+	const pkgPath = path.join(dir, 'package.json')
+	const binPath = path.join(dir, binaryName)
+
+	if (!fs.existsSync(pkgPath)) {
+		console.error(`[publish-platform-packages] MISSING package.json in ${dir}`)
+		process.exit(1)
+	}
+	if (!fs.existsSync(binPath)) {
+		console.error(`[publish-platform-packages] MISSING ${binaryName} in ${dir}`)
+		process.exit(1)
+	}
+	const size = fs.statSync(binPath).size
+	if (size < minBytes) {
+		console.error(
+			`[publish-platform-packages] ${binPath} too small (${size} bytes); assemble natives first`,
+		)
+		process.exit(1)
+	}
+	fs.chmodSync(binPath, 0o755)
+
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name: string; version: string }
+	console.log(`[publish-platform-packages] ${pkg.name}@${pkg.version} (${platform}, ${size} bytes)`)
+
+	if (packageExists(pkg.name, pkg.version)) {
+		console.log(`[publish-platform-packages] SKIP already published ${pkg.name}@${pkg.version}`)
+		skipped++
+		continue
+	}
+
+	const result = spawnSync(
+		'npm',
+		['publish', '--access', 'public', '--registry', 'https://registry.npmjs.org/'],
+		{
+			cwd: dir,
+			encoding: 'utf8',
+			env: process.env,
+			stdio: 'inherit',
+		},
+	)
+	if (result.status !== 0) {
+		console.error(`[publish-platform-packages] FAIL npm publish ${pkg.name}@${pkg.version}`)
+		process.exit(result.status ?? 1)
+	}
+	published++
+	console.log(`[publish-platform-packages] OK ${pkg.name}@${pkg.version}`)
+}
+
+console.log(
+	`[publish-platform-packages] Done: published=${published} skipped=${skipped} total=${platforms.length}`,
+)

--- a/scripts/stage-rust-mcp.ts
+++ b/scripts/stage-rust-mcp.ts
@@ -1,10 +1,21 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 const repoRoot = path.resolve(import.meta.dirname, '..')
 const source = path.join(repoRoot, 'target/release/filesystem-mcp-server')
 const targetDir = path.join(repoRoot, 'bin/native')
 const target = path.join(targetDir, 'filesystem-mcp-server')
+
+function hostPlatformDir(): string | null {
+	const platform = os.platform()
+	const arch = os.arch()
+	if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+	if (platform === 'darwin' && arch === 'x64') return 'darwin-x64'
+	if (platform === 'linux' && arch === 'x64') return 'linux-x64-gnu'
+	if (platform === 'linux' && arch === 'arm64') return 'linux-arm64-gnu'
+	return null
+}
 
 if (!fs.existsSync(source)) {
 	console.error(`[stage-rust-mcp] Missing release binary at ${source}. Run: bun run build:rust`)
@@ -14,5 +25,14 @@ if (!fs.existsSync(source)) {
 fs.mkdirSync(targetDir, { recursive: true })
 fs.copyFileSync(source, target)
 fs.chmodSync(target, 0o755)
-
 console.log(`[stage-rust-mcp] Staged ${target}`)
+
+// Also stage host platform optionalDependency package binary for local smoke.
+const platformDir = hostPlatformDir()
+if (platformDir) {
+	const platformTarget = path.join(repoRoot, 'npm', platformDir, 'filesystem-mcp-server')
+	fs.mkdirSync(path.dirname(platformTarget), { recursive: true })
+	fs.copyFileSync(source, platformTarget)
+	fs.chmodSync(platformTarget, 0o755)
+	console.log(`[stage-rust-mcp] Staged platform package binary ${platformTarget}`)
+}

--- a/scripts/sync-platform-versions.ts
+++ b/scripts/sync-platform-versions.ts
@@ -1,0 +1,56 @@
+/**
+ * Sync optionalDependency + platform package versions to @sylphx/filesystem-mcp version.
+ * Run after `changeset version` so platform packages publish at the same version.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+const mcpPackagePath = path.join(repoRoot, 'package.json')
+const mcpPkg = JSON.parse(fs.readFileSync(mcpPackagePath, 'utf8')) as {
+	version: string
+	optionalDependencies?: Record<string, string>
+}
+
+const version = mcpPkg.version
+const platformDir = path.join(repoRoot, 'npm')
+const platforms = fs
+	.readdirSync(platformDir, { withFileTypes: true })
+	.filter((e) => e.isDirectory())
+	.map((e) => e.name)
+
+const expectedOptional: Record<string, string> = {}
+let updated = false
+
+for (const platform of platforms) {
+	const pkgPath = path.join(platformDir, platform, 'package.json')
+	if (!fs.existsSync(pkgPath)) continue
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+		name: string
+		version: string
+	}
+	expectedOptional[pkg.name] = version
+	if (pkg.version !== version) {
+		console.log(`[sync-platform-versions] ${pkg.name}: ${pkg.version} → ${version}`)
+		pkg.version = version
+		fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+		updated = true
+	}
+}
+
+const currentOptional = mcpPkg.optionalDependencies ?? {}
+const nextOptional = { ...currentOptional, ...expectedOptional }
+const optionalChanged = JSON.stringify(currentOptional) !== JSON.stringify(nextOptional)
+
+if (optionalChanged) {
+	mcpPkg.optionalDependencies = nextOptional
+	fs.writeFileSync(mcpPackagePath, `${JSON.stringify(mcpPkg, null, 2)}\n`)
+	console.log(`[sync-platform-versions] Updated optionalDependencies to ${version}`)
+	updated = true
+}
+
+if (!updated) {
+	console.log(`[sync-platform-versions] Already synced at ${version}`)
+} else {
+	console.log(`[sync-platform-versions] Done (mcp @ ${version})`)
+}

--- a/scripts/verify-multiarch-readback.ts
+++ b/scripts/verify-multiarch-readback.ts
@@ -1,0 +1,111 @@
+/**
+ * Post-publish readback: confirm platform packages exist on npm for the mcp version.
+ *
+ * - Version-PR path: SKIP if main package version not on registry yet.
+ * - Publish path: fail-closed if platform packages missing.
+ * - Uses version-specific tarball HEAD (full application/json packument can
+ *   lag several minutes after first publish of a new package name).
+ */
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+const mcpPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+	version: string
+	optionalDependencies?: Record<string, string>
+}
+
+const version = mcpPkg.version
+const optional = mcpPkg.optionalDependencies ?? {}
+const platformNames = Object.keys(optional).filter((n) => n.startsWith('@sylphx/filesystem-mcp-'))
+
+if (platformNames.length === 0) {
+	console.error('[verify-multiarch-readback] No platform optionalDependencies declared')
+	process.exit(1)
+}
+
+function sleep(ms: number): void {
+	spawnSync('sleep', [String(ms / 1000)], { stdio: 'ignore' })
+}
+
+function tarballUrl(name: string, ver: string): string {
+	const scopedPath = name.startsWith('@') ? name.replace('/', '%2f') : name
+	const shortName = name.includes('/') ? name.split('/')[1]! : name
+	return `https://registry.npmjs.org/${scopedPath}/-/${shortName}-${ver}.tgz`
+}
+
+function tarballExists(name: string, ver: string): boolean {
+	const url = tarballUrl(name, ver)
+	const result = spawnSync(
+		'curl',
+		['-sS', '-o', '/dev/null', '-w', '%{http_code}', '-L', '-I', url],
+		{ encoding: 'utf8' },
+	)
+	return result.status === 0 && (result.stdout || '').trim().split('\n').pop() === '200'
+}
+
+function npmViewVersion(name: string, ver: string): boolean {
+	const view = spawnSync('npm', ['view', `${name}@${ver}`, 'version', '--json'], {
+		encoding: 'utf8',
+	})
+	if (view.status !== 0) return false
+	const raw = (view.stdout || '').trim()
+	try {
+		const parsed = JSON.parse(raw) as string | string[]
+		if (typeof parsed === 'string') return parsed === ver
+		if (Array.isArray(parsed)) return parsed.includes(ver)
+	} catch {
+		return raw.replace(/"/g, '') === ver
+	}
+	return raw.includes(ver)
+}
+
+function packageExists(name: string, ver: string): boolean {
+	// Version-specific tarball is authoritative and available before full packument.
+	if (tarballExists(name, ver)) return true
+	// Fallback after packument replication.
+	return npmViewVersion(name, ver)
+}
+
+function packageExistsWithRetry(name: string, ver: string, attempts = 10): boolean {
+	for (let i = 0; i < attempts; i++) {
+		if (packageExists(name, ver)) return true
+		const waitMs = Math.min(20_000, 2000 * (i + 1))
+		console.log(
+			`[verify-multiarch-readback] waiting for registry: ${name}@${ver} (attempt ${i + 1}/${attempts}, sleep ${waitMs}ms)`,
+		)
+		sleep(waitMs)
+	}
+	return false
+}
+
+// Version-PR-only Release runs still invoke postpublish after creating the
+// Changesets version PR (published=false). Skip fail-closed readback until
+// the version actually exists on the registry.
+if (!packageExists('@sylphx/filesystem-mcp', version)) {
+	console.log(
+		`[verify-multiarch-readback] SKIP: @sylphx/filesystem-mcp@${version} not on registry yet (version PR path; publish happens after version PR merge)`,
+	)
+	process.exit(0)
+}
+
+let failed = 0
+for (const name of platformNames) {
+	const expected = optional[name]
+	if (packageExistsWithRetry(name, expected)) {
+		console.log(`[verify-multiarch-readback] OK ${name}@${expected}`)
+	} else {
+		failed++
+		console.error(`[verify-multiarch-readback] MISSING ${name}@${expected}`)
+	}
+}
+
+if (failed > 0) {
+	console.error(`[verify-multiarch-readback] FAIL: ${failed} package(s) missing on registry`)
+	process.exit(1)
+}
+
+console.log(
+	`[verify-multiarch-readback] PASS: ${platformNames.length} platform packages @ ${version}`,
+)

--- a/scripts/verify-multiarch-readback.ts
+++ b/scripts/verify-multiarch-readback.ts
@@ -31,7 +31,7 @@ function sleep(ms: number): void {
 
 function tarballUrl(name: string, ver: string): string {
 	const scopedPath = name.startsWith('@') ? name.replace('/', '%2f') : name
-	const shortName = name.includes('/') ? name.split('/')[1]! : name
+	const shortName = name.includes('/') ? (name.split('/')[1] ?? name) : name
 	return `https://registry.npmjs.org/${scopedPath}/-/${shortName}-${ver}.tgz`
 }
 

--- a/scripts/verify-multiarch-readback.ts
+++ b/scripts/verify-multiarch-readback.ts
@@ -30,7 +30,8 @@ function sleep(ms: number): void {
 }
 
 function tarballUrl(name: string, ver: string): string {
-	const scopedPath = name.startsWith('@') ? name.replace('/', '%2f') : name
+	// Encode every "/" for the npm registry path (scoped packages are @scope/name).
+	const scopedPath = name.startsWith('@') ? name.split('/').join('%2f') : name
 	const shortName = name.includes('/') ? (name.split('/')[1] ?? name) : name
 	return `https://registry.npmjs.org/${scopedPath}/-/${shortName}-${ver}.tgz`
 }


### PR DESCRIPTION
## Summary

- Ship multi-arch native MCP binaries via `optionalDependencies` platform packages:
  - `@sylphx/filesystem-mcp-darwin-arm64`
  - `@sylphx/filesystem-mcp-darwin-x64`
  - `@sylphx/filesystem-mcp-linux-x64-gnu`
  - `@sylphx/filesystem-mcp-linux-arm64-gnu`
- Arch-aware `bin/filesystem-mcp` resolves platform-matched optionalDep, rejects wrong-arch staged ELF, keeps TS transport as explicit opt-in
- Release workflow matrix-builds natives, assembles packages fail-closed, publishes platform packages then main
- Version **0.7.1** included so main-tip merge publishes immediately (addresses npm 0.7.0 unbound + linux-only ELF residual)

## Packet

`FILESYSTEM-MCP-MULTIARCH-TICK014` — mirrors CodeRAG optionalDeps pattern for single-package layout.

## Test plan

- [x] Boundary tests pass (arch-aware wrapper contracts)
- [ ] CI: Native multi-arch assemble-check
- [ ] CI: validate / merge_group
- [ ] Release publishes 0.7.1 + 4 platform packages
- [ ] Darwin arm64 consumer smoke of published artifact