### PR TITLE
feat(parity): expand main differential to read_content + write_content (tick-016)

### DIFF
--- a/.github/workflows/rust-parity-differential.yml
+++ b/.github/workflows/rust-parity-differential.yml
@@ -1,5 +1,5 @@
-# Filesystem MCP list_files TS↔Rust differential parity (rej-010 / tick-010).
-# Main-bound single capability slice — not full tool authority.
+# Filesystem MCP TS↔Rust differential parity (rej-010 / tick-016).
+# Main-bound fail-closed slices: list-files + read-content + write-content.
 # Adopts rust-parity-drift-pass control-plane template: map-and-stale + differential + fan-in.
 # Workflow fixes from coderag/flux/gateway: no runner.temp at job env; CHANGED via env not <<<.
 name: rust-parity-differential
@@ -101,8 +101,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run differential harness (list-files)
-        run: bash "${DIFFERENTIAL_SCRIPT}" --slice list-files
+      - name: Run differential harness (list-files + read-content + write-content)
+        run: bash "${DIFFERENTIAL_SCRIPT}" --slice all
 
       - name: Assert proof SHA binding
         run: |
@@ -115,19 +115,27 @@ jobs:
           LAST_COMPARED="$(jq -r '.lastComparedMainSha' "$ARTIFACT")"
           STATUS="$(jq -r '.status' "$ARTIFACT")"
           SLICE="$(jq -r '.slice' "$ARTIFACT")"
+          CASE_COUNT="$(jq -r '.caseCount' "$ARTIFACT")"
+          LIST_COUNT="$(jq -r '.listFilesCaseCount // 0' "$ARTIFACT")"
+          READ_COUNT="$(jq -r '.readContentCaseCount // 0' "$ARTIFACT")"
+          WRITE_COUNT="$(jq -r '.writeContentCaseCount // 0' "$ARTIFACT")"
           if [ "$STATUS" != "differential_green" ]; then
             echo "::error::verification status must be differential_green (got $STATUS)"
             exit 1
           fi
-          if [[ "$SLICE" != *"list-files"* ]]; then
-            echo "::error::expected list-files slice (got $SLICE)"
+          if [[ "$SLICE" != *"list-files"* ]] && [[ "$SLICE" != *"read_content"* ]] && [[ "$SLICE" != *"write_content"* ]]; then
+            echo "::error::expected expanded multi-tool slice (got $SLICE)"
+            exit 1
+          fi
+          if [ "$LIST_COUNT" -lt 2 ] || [ "$READ_COUNT" -lt 4 ] || [ "$WRITE_COUNT" -lt 4 ]; then
+            echo "::error::case floors not met list=$LIST_COUNT read=$READ_COUNT write=$WRITE_COUNT total=$CASE_COUNT"
             exit 1
           fi
           if [ "$LAST_COMPARED" != "$CANDIDATE_SHA" ]; then
             echo "::error::proof SHA binding failed: lastComparedMainSha=$LAST_COMPARED candidate=$CANDIDATE_SHA"
             exit 1
           fi
-          echo "proof SHA binding OK: lastComparedMainSha=$LAST_COMPARED slice=$SLICE"
+          echo "proof SHA binding OK: lastComparedMainSha=$LAST_COMPARED slice=$SLICE cases=$CASE_COUNT list=$LIST_COUNT read=$READ_COUNT write=$WRITE_COUNT"
 
       - name: Warn on stale capabilities without re-proof
         if: needs.map-and-stale.outputs.stale_capabilities != '[]'
@@ -168,4 +176,4 @@ jobs:
             echo "::error::rust-parity-drift-pass failed — differential parity not proven at candidate SHA"
             exit 1
           fi
-          echo "rust-parity-drift-pass OK (list-files)"
+          echo "rust-parity-drift-pass OK (list-files|read-content|write-content)"

--- a/__tests__/differentialHarness.matrix.test.ts
+++ b/__tests__/differentialHarness.matrix.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 const repoRoot = path.resolve(import.meta.dirname, '..')
 
-describe('filesystem-mcp differential harness (rej-010 list-files)', () => {
+describe('filesystem-mcp differential harness (rej-010 tick-016 multi-tool)', () => {
 	it('ships fail-closed differential entrypoint and oracle artifacts', () => {
 		expect(existsSync(path.join(repoRoot, 'scripts/run-filesystem-mcp-differential.sh'))).toBe(true)
 		expect(existsSync(path.join(repoRoot, 'scripts/differential/filesystem-mcp-oracle.ts'))).toBe(true)
@@ -17,33 +17,73 @@ describe('filesystem-mcp differential harness (rej-010 list-files)', () => {
 		expect(harness).toContain('filesystem-mcp-differential')
 		expect(harness).toContain('filesystem-mcp-oracle.ts')
 		expect(harness).toContain('list_files_differential_matches_ts_oracle')
+		expect(harness).toContain('read_content_differential_matches_ts_oracle')
+		expect(harness).toContain('write_content_differential_matches_ts_oracle')
 		expect(harness).toContain('--slice')
 		expect(harness).toContain('differential_green')
+		// Fail-closed allow-list
+		expect(harness).toContain('list-files|read-content|write-content')
+		expect(harness).toContain('invalid --slice value')
 	})
 
-	it('parity slice manifest binds list_files bounded domain', () => {
+	it('parity slice manifest binds list_files + read_content + write_content', () => {
 		const slice = JSON.parse(
 			readFileSync(path.join(repoRoot, 'docs/specs/filesystem-mcp-parity-slice.json'), 'utf8'),
 		) as {
 			slice: string
 			differentialHarness: string
-			domains: Array<{ id: string; differentialTest: boolean; boundedSlice?: string }>
+			domains: Array<{ id: string; differentialTest: boolean; boundedSlice?: string; minCases?: number }>
 		}
 
 		expect(slice.slice).toContain('tool.list_files')
+		expect(slice.slice).toContain('tool.read_content')
+		expect(slice.slice).toContain('tool.write_content')
 		expect(slice.differentialHarness).toBe('scripts/run-filesystem-mcp-differential.sh')
 		expect(slice.domains.some((domain) => domain.id === 'tool/list_files')).toBe(true)
+		expect(slice.domains.some((domain) => domain.id === 'tool/read_content')).toBe(true)
+		expect(slice.domains.some((domain) => domain.id === 'tool/write_content')).toBe(true)
 		expect(slice.domains.find((domain) => domain.id === 'tool/list_files')?.boundedSlice).toBe('list-files')
+		expect(slice.domains.find((domain) => domain.id === 'tool/read_content')?.boundedSlice).toBe('read-content')
+		expect(slice.domains.find((domain) => domain.id === 'tool/write_content')?.boundedSlice).toBe('write-content')
+		expect(slice.domains.find((domain) => domain.id === 'tool/read_content')?.minCases).toBeGreaterThanOrEqual(4)
+		expect(slice.domains.find((domain) => domain.id === 'tool/write_content')?.minCases).toBeGreaterThanOrEqual(4)
 	})
 
-	it('list-read golden fixture drives bounded list_files oracle cases', () => {
-		const golden = JSON.parse(
+	it('golden fixtures drive bounded oracle cases for each expanded tool', () => {
+		const listRead = JSON.parse(
 			readFileSync(path.join(repoRoot, 'test/fixtures/golden/list_read.golden.json'), 'utf8'),
 		) as {
 			cases: Array<{ tool: string }>
 		}
+		const write = JSON.parse(
+			readFileSync(path.join(repoRoot, 'test/fixtures/golden/write_content.golden.json'), 'utf8'),
+		) as {
+			cases: Array<{ tool: string }>
+		}
 
-		const listCases = golden.cases.filter((testCase) => testCase.tool === 'list_files')
+		const listCases = listRead.cases.filter((testCase) => testCase.tool === 'list_files')
+		const readCases = listRead.cases.filter((testCase) => testCase.tool === 'read_content')
+		const writeCases = write.cases.filter((testCase) => testCase.tool === 'write_content')
 		expect(listCases.length).toBeGreaterThanOrEqual(2)
+		expect(readCases.length).toBeGreaterThanOrEqual(4)
+		expect(writeCases.length).toBeGreaterThanOrEqual(4)
+	})
+
+	it('corpus allow-list is fail-closed to expanded RustCore tools only', () => {
+		const corpus = JSON.parse(
+			readFileSync(path.join(repoRoot, 'scripts/differential/fixtures/filesystem-mcp-corpus.json'), 'utf8'),
+		) as {
+			toolRouteCases: Array<{ tool: string; expect: string }>
+			serverContract: { tools: string[] }
+		}
+
+		const allowed = new Set(['list_files', 'read_content', 'write_content'])
+		for (const route of corpus.toolRouteCases) {
+			expect(allowed.has(route.tool)).toBe(true)
+			expect(route.expect).toBe('RustCore')
+		}
+		for (const tool of corpus.serverContract.tools) {
+			expect(allowed.has(tool)).toBe(true)
+		}
 	})
 })

--- a/bun.lock
+++ b/bun.lock
@@ -30,10 +30,10 @@
         "vitest": "^3.1.1",
       },
       "optionalDependencies": {
-        "@sylphx/filesystem-mcp-darwin-arm64": "0.7.0",
-        "@sylphx/filesystem-mcp-darwin-x64": "0.7.0",
-        "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.0",
-        "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.0",
+        "@sylphx/filesystem-mcp-darwin-arm64": "0.7.1",
+        "@sylphx/filesystem-mcp-darwin-x64": "0.7.1",
+        "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.1",
+        "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.1",
       },
     },
   },
@@ -323,6 +323,14 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sylphx/biome-config": ["@sylphx/biome-config@0.4.1", "", { "peerDependencies": { "@biomejs/biome": "^2.0.0" } }, "sha512-yNdrXKcnhrXK+OB2WLEJix6cryj3PME5DbKpGFMJGA6/B1/+mpk2ChKiohifrf956FKQ3JTAqhLhZfY7lu18yA=="],
+
+    "@sylphx/filesystem-mcp-darwin-arm64": ["@sylphx/filesystem-mcp-darwin-arm64@0.7.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-J2Ckvhx++lUlffOZop+w3Do4Gw3I4/nTEhkBRRj5/mP649SX9kahSLJLkiK/gHYNUfXVJBDzE8DSPp2NRfDYvg=="],
+
+    "@sylphx/filesystem-mcp-darwin-x64": ["@sylphx/filesystem-mcp-darwin-x64@0.7.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dqbUDRkZhRpD0oo0SM8xbK3hZAeNqMo7PaDmCURw3nNVN9OEnT4EvQAVH2XMkrU2xDPXs9VIRkrV08EWCUVEHA=="],
+
+    "@sylphx/filesystem-mcp-linux-arm64-gnu": ["@sylphx/filesystem-mcp-linux-arm64-gnu@0.7.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-2MpDxYFMHggE7ss+gG+ZdF8N0wSG9uK9pO+ZfDPtrp9whWb7lIH4QXZmt6VxanEwmPnWNSO1Fn+jSzMjNn0EPw=="],
+
+    "@sylphx/filesystem-mcp-linux-x64-gnu": ["@sylphx/filesystem-mcp-linux-x64-gnu@0.7.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cnbwWaByWtw5fyslp/XBEXiD0V+vzBPXObfk7oG2nbk1C1nd/9TsLPxFnSgZ69yBUA8b8ojWRsVmEOYuo/Rm7Q=="],
 
     "@sylphx/tsconfig": ["@sylphx/tsconfig@0.3.1", "", {}, "sha512-S7JAV9OEt3LUChz1jmFMG2coJGYdmSF+n4x6lPK9JziykFCvS37d4G5uoBS2kWVW4grnZa+WRmAtZkE9oMFi0Q=="],
 

--- a/crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs
+++ b/crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs
@@ -15,10 +15,14 @@ use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 
 const LIST_FILES_SLICE: &str = "list-files";
 const READ_CONTENT_SLICE: &str = "read-content";
 const WRITE_CONTENT_SLICE: &str = "write-content";
+
+/// Serialize tool cases that mutate isolated corpus trees (write_content).
+static TOOL_CASE_LOCK: Mutex<()> = Mutex::new(());
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
@@ -62,7 +66,7 @@ fn reset_isolated_corpus(case: &OracleCase) {
     copy_dir_all(&golden_corpus_root(), &destination);
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct OracleCase {
     id: String,
     slice: String,
@@ -71,7 +75,7 @@ struct OracleCase {
     output: Value,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct OracleCorpus {
     corpus_version: u32,
@@ -80,7 +84,7 @@ struct OracleCorpus {
     cases: Vec<OracleCase>,
 }
 
-fn run_ts_oracle() -> OracleCorpus {
+fn load_oracle_from_env_or_spawn() -> OracleCorpus {
     if let Ok(path) = std::env::var("FILESYSTEM_MCP_ORACLE_JSON") {
         let raw = fs::read_to_string(&path)
             .unwrap_or_else(|error| panic!("read FILESYSTEM_MCP_ORACLE_JSON at {path}: {error}"));
@@ -89,9 +93,14 @@ fn run_ts_oracle() -> OracleCorpus {
 
     let script = repo_root().join("scripts/differential/filesystem-mcp-oracle.ts");
     // Unique scratch under repo root (PROJECT_ROOT confinement rejects /tmp paths).
+    // Include a random suffix so concurrent cargo-test workers never clobber each other.
     let scratch = repo_root().join(format!(
-        "test/fixtures/differential-scratch-{}",
-        std::process::id()
+        "test/fixtures/differential-scratch-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
     ));
     let _ = fs::remove_dir_all(&scratch);
     fs::create_dir_all(&scratch).expect("create oracle scratch");
@@ -111,6 +120,13 @@ fn run_ts_oracle() -> OracleCorpus {
     );
 
     serde_json::from_slice(&output.stdout).expect("oracle output must be valid JSON")
+}
+
+/// Cache oracle once per test process so parallel `cargo test` workers share a
+/// single TS baseline (avoids scratch rm/race between list/read/write slices).
+fn run_ts_oracle() -> OracleCorpus {
+    static ORACLE: OnceLock<OracleCorpus> = OnceLock::new();
+    ORACLE.get_or_init(load_oracle_from_env_or_spawn).clone()
 }
 
 fn sorted_string_array(value: &Value) -> Value {
@@ -178,6 +194,18 @@ fn compare_tool_case(case: &OracleCase) {
     let tool = case.input["tool"].as_str().expect("tool case tool name");
     let root = case.input["root"].as_str().expect("tool case root");
     let args = case.input["args"].clone();
+
+    // Isolate-mutating tools (write_content) must not race with each other under cargo test.
+    let _guard = if case
+        .input
+        .get("isolate")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        Some(TOOL_CASE_LOCK.lock().expect("tool case lock"))
+    } else {
+        None
+    };
 
     reset_isolated_corpus(case);
 

--- a/crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs
+++ b/crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs
@@ -1,8 +1,10 @@
-//! TRUE differential parity: TS contract oracle vs native Rust list_files SSOT.
+//! TRUE differential parity: TS contract oracle vs native Rust MCP tool SSOT.
 //!
 //! Fail-closed — no SKIP-as-pass. Oracle subprocess must succeed before comparison.
-//! Bounded slice (rej-010 / tick-010):
-//! - `list_files_differential_matches_ts_oracle` — S1 discovery path (2 cases)
+//! Bounded slices (rej-010 / tick-016 main expansion):
+//! - `list_files_differential_matches_ts_oracle` — S1 discovery (2 cases)
+//! - `read_content_differential_matches_ts_oracle` — S1 read path (4 cases)
+//! - `write_content_differential_matches_ts_oracle` — S2 mutation path (4 cases)
 //! See scripts/run-filesystem-mcp-differential.sh.
 
 use filesystem_mcp_server::cli_bridge;
@@ -15,6 +17,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const LIST_FILES_SLICE: &str = "list-files";
+const READ_CONTENT_SLICE: &str = "read-content";
+const WRITE_CONTENT_SLICE: &str = "write-content";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
@@ -120,11 +124,44 @@ fn sorted_string_array(value: &Value) -> Value {
     Value::Array(entries.into_iter().map(Value::String).collect())
 }
 
+fn normalize_write_payload(payload: &Value) -> Value {
+    let entries = payload
+        .as_array()
+        .expect("write_content array payload")
+        .iter()
+        .map(|entry| {
+            let object = entry.as_object().expect("write_content result object");
+            let mut normalized = serde_json::Map::new();
+            normalized.insert(
+                "path".into(),
+                object.get("path").cloned().unwrap_or(Value::Null),
+            );
+            normalized.insert(
+                "success".into(),
+                object.get("success").cloned().unwrap_or(Value::Null),
+            );
+            normalized.insert(
+                "operation".into(),
+                object.get("operation").cloned().unwrap_or(Value::Null),
+            );
+            if let Some(code) = object.get("code").filter(|value| !value.is_null()) {
+                normalized.insert("code".into(), code.clone());
+            }
+            if let Some(error) = object.get("error").filter(|value| !value.is_null()) {
+                normalized.insert("error".into(), error.clone());
+            }
+            Value::Object(normalized)
+        })
+        .collect::<Vec<_>>();
+    Value::Array(entries)
+}
+
 fn normalize_tool_payload(tool: &str, payload: Value) -> Value {
-    if tool == "list_files" {
-        return sorted_string_array(&payload);
+    match tool {
+        "list_files" => sorted_string_array(&payload),
+        "write_content" => normalize_write_payload(&payload),
+        _ => payload,
     }
-    payload
 }
 
 fn parse_rmcp_text_payload(result: &rmcp::model::CallToolResult) -> Value {
@@ -223,6 +260,14 @@ fn assert_slice_metadata(case: &OracleCase) {
             assert_eq!(case.domain, "tool");
             assert_eq!(case.input["tool"].as_str(), Some("list_files"));
         }
+        READ_CONTENT_SLICE => {
+            assert_eq!(case.domain, "tool");
+            assert_eq!(case.input["tool"].as_str(), Some("read_content"));
+        }
+        WRITE_CONTENT_SLICE => {
+            assert_eq!(case.domain, "tool");
+            assert_eq!(case.input["tool"].as_str(), Some("write_content"));
+        }
         "tool-route-contract" => assert_eq!(case.domain, "toolRouteContract"),
         "server-contract" => assert_eq!(case.domain, "serverContract"),
         other => panic!("unknown slice {other} for case {}", case.id),
@@ -269,3 +314,12 @@ fn list_files_differential_matches_ts_oracle() {
     run_bounded_slice(LIST_FILES_SLICE, 2);
 }
 
+#[test]
+fn read_content_differential_matches_ts_oracle() {
+    run_bounded_slice(READ_CONTENT_SLICE, 4);
+}
+
+#[test]
+fn write_content_differential_matches_ts_oracle() {
+    run_bounded_slice(WRITE_CONTENT_SLICE, 4);
+}

--- a/docs/specs/filesystem-mcp-parity-slice.json
+++ b/docs/specs/filesystem-mcp-parity-slice.json
@@ -2,12 +2,12 @@
 	"schemaVersion": 1,
 	"repo": "SylphxAI/filesystem-mcp",
 	"reauditRef": "rej-010",
-	"slice": "tool.list_files",
+	"slice": "tool.list_files|tool.read_content|tool.write_content",
 	"differentialHarness": "scripts/run-filesystem-mcp-differential.sh",
 	"oracle": "scripts/differential/filesystem-mcp-oracle.ts",
 	"behaviorSpec": "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-	"goldenFixture": "test/fixtures/golden/list_read.golden.json",
-	"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
+	"goldenFixture": "test/fixtures/golden/list_read.golden.json; test/fixtures/golden/write_content.golden.json",
+	"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle;read_content_differential_matches_ts_oracle;write_content_differential_matches_ts_oracle",
 	"domains": [
 		{
 			"id": "tool/list_files",
@@ -15,7 +15,21 @@
 			"boundedSlice": "list-files",
 			"minCases": 2,
 			"fixture": "test/fixtures/golden/list_read.golden.json"
+		},
+		{
+			"id": "tool/read_content",
+			"differentialTest": true,
+			"boundedSlice": "read-content",
+			"minCases": 4,
+			"fixture": "test/fixtures/golden/list_read.golden.json"
+		},
+		{
+			"id": "tool/write_content",
+			"differentialTest": true,
+			"boundedSlice": "write-content",
+			"minCases": 4,
+			"fixture": "test/fixtures/golden/write_content.golden.json"
 		}
 	],
-	"notes": "tick-010 rej-010: main-bound list_files differential harness. Does not promote authority_rust or ts_deleted."
+	"notes": "tick-016 rej-010: main-bound differential expansion beyond list_files to read_content + write_content. Fail-closed allow-list. Does not promote authority_rust or ts_deleted."
 }

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -17,7 +17,10 @@
 			"note": "North Star ADR on disk \u2014 pending ADR PR; ADR number will equal introducing PR number per Doctrine"
 		}
 	],
-	"inventorySource": ["mcp-tools", "manual"],
+	"inventorySource": [
+		"mcp-tools",
+		"manual"
+	],
 	"inScopeBoundary": {
 		"includeGlobs": [
 			"src/**",
@@ -28,7 +31,11 @@
 			"__tests__/**",
 			"scripts/differential/**"
 		],
-		"excludeGlobs": ["node_modules/**", "dist/**", "coverage/**"]
+		"excludeGlobs": [
+			"node_modules/**",
+			"dist/**",
+			"coverage/**"
+		]
 	},
 	"capabilities": [
 		{
@@ -63,7 +70,7 @@
 			"state": "rust_impl",
 			"promotionHold": {
 				"active": true,
-				"reason": "rej-010: main-bound list_files differential harness lands tick-010 \u2014 promotion_hold until prod_audit_pass",
+				"reason": "rej-010: main-bound multi-tool differential (list/read/write) \u2014 promotion_hold until prod_audit_pass",
 				"rejectionRef": "rej-010",
 				"since": "2026-07-11T00:00:00+00:00"
 			},
@@ -86,8 +93,8 @@
 			"rustSurface": "crates/filesystem-core/src/walk.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice list-files",
-			"branch": "feat/list-files-main-differential",
-			"notes": "tick-010: main-bound list_files differential harness + MCP-shaped CLI path. rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010). TS residual via FILESYSTEM_MCP_TRANSPORT=ts / FILESYSTEM_USE_RUST_WALK not set."
+			"branch": "feat/expand-diff-main-tick016",
+			"notes": "tick-016: main-bound differential remains list_files + expanded siblings. rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
 		},
 		{
 			"id": "tool/search_files",
@@ -105,34 +112,31 @@
 			"state": "rust_impl",
 			"promotionHold": {
 				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"reason": "rej-010: main-bound read_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
 				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
+				"since": "2026-07-11T00:00:00+00:00"
 			},
 			"proof": {
-				"status": "differential_green",
-				"baselineTsSha": "09773f7ecbacf1ebf0c9cc123c1be8108f9c7675",
-				"rustCandidateSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"lastComparedMainSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"mergeGroupSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"behaviorSpecHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"fixtureCorpusHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"verifiedAt": "2026-07-10T10:53:32+00:00",
-				"verificationRef": "verification/filesystem-mcp-differential-green.json",
-				"harness": "scripts/run-filesystem-mcp-differential.sh",
-				"caseCount": 36,
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice read-content",
 				"dependencyGlobs": [
 					"src/handlers/read-content.ts",
+					"src/engine/rust-content.ts",
+					"crates/filesystem-core/src/content.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
 					"test/fixtures/golden/list_read.golden.json",
-					"scripts/differential/**"
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
 				]
 			},
 			"tsSurface": "src/handlers/read-content.ts; src/engine/rust-content.ts (opt-out via FILESYSTEM_USE_RUST_CONTENT=ts)",
 			"rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice read-content",
-			"branch": "feat/rust-web-mcp-http-transport",
-			"notes": "Cycle28 rej-010 bounded slice: read_content_differential_matches_ts_oracle (4 cases). cycle38: parity-slice manifest + matrix gate landed. S1 read path. proof.status missing until differential_green at bound SHAs. authority_rust NOT claimed."
+			"branch": "feat/expand-diff-main-tick016",
+			"notes": "tick-016: main-bound read_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
 		},
 		{
 			"id": "tool/write_content",
@@ -141,24 +145,19 @@
 			"state": "rust_impl",
 			"promotionHold": {
 				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"reason": "rej-010: main-bound write_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
 				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
+				"since": "2026-07-11T00:00:00+00:00"
 			},
 			"proof": {
-				"status": "differential_green",
-				"baselineTsSha": "09773f7ecbacf1ebf0c9cc123c1be8108f9c7675",
-				"rustCandidateSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"lastComparedMainSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"mergeGroupSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"behaviorSpecHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"fixtureCorpusHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"verifiedAt": "2026-07-10T10:53:32+00:00",
-				"verificationRef": "verification/filesystem-mcp-differential-green.json",
-				"harness": "scripts/run-filesystem-mcp-differential.sh",
-				"caseCount": 36,
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice write-content",
 				"dependencyGlobs": [
 					"src/handlers/write-content.ts",
+					"src/engine/rust-write.ts",
+					"crates/filesystem-core/src/content.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
 					"test/fixtures/golden/write_content.golden.json",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh",
@@ -169,8 +168,8 @@
 			"rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/write_content.golden.json; __tests__/engine/writeContentGoldenParity.test.ts; cargo test -p filesystem-cli --test write_content_golden_parity",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice write-content",
-			"branch": "feat/rust-web-mcp-http-transport",
-			"notes": "S2 mutation slice: golden MCP parity; cycle43 rej-010 write-content bounded differential harness. proof.status missing until differential_green. authority_rust NOT claimed."
+			"branch": "feat/expand-diff-main-tick016",
+			"notes": "tick-016: main-bound write_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
 		},
 		{
 			"id": "tool/stat_items",
@@ -211,30 +210,22 @@
 				"since": "2026-07-10T10:53:32+00:00"
 			},
 			"proof": {
-				"status": "differential_green",
-				"baselineTsSha": "09773f7ecbacf1ebf0c9cc123c1be8108f9c7675",
-				"rustCandidateSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"lastComparedMainSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"mergeGroupSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"behaviorSpecHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"fixtureCorpusHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"verifiedAt": "2026-07-10T10:53:32+00:00",
-				"verificationRef": "verification/filesystem-mcp-differential-green.json",
-				"harness": "scripts/run-filesystem-mcp-differential.sh",
-				"caseCount": 36,
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
 				"dependencyGlobs": [
 					"src/handlers/chmod-items.ts",
 					"crates/filesystem-core/src/chmod_items.rs",
 					"test/fixtures/golden/chmod_items.golden.json",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh"
-				]
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
 			},
 			"tsSurface": "src/handlers/chmod-items.ts",
 			"rustSurface": "crates/filesystem-core/src/chmod_items.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/chmod_items.golden.json; __tests__/handlers/chmod-items.test.ts",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-			"notes": "Cycle63 rej-010: chmod_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed."
+			"notes": "Cycle63 rej-010: chmod_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
 		},
 		{
 			"id": "tool/chown_items",
@@ -248,30 +239,22 @@
 				"since": "2026-07-10T10:53:32+00:00"
 			},
 			"proof": {
-				"status": "differential_green",
-				"baselineTsSha": "09773f7ecbacf1ebf0c9cc123c1be8108f9c7675",
-				"rustCandidateSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"lastComparedMainSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"mergeGroupSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"behaviorSpecHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"fixtureCorpusHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"verifiedAt": "2026-07-10T10:53:32+00:00",
-				"verificationRef": "verification/filesystem-mcp-differential-green.json",
-				"harness": "scripts/run-filesystem-mcp-differential.sh",
-				"caseCount": 36,
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
 				"dependencyGlobs": [
 					"src/handlers/chown-items.ts",
 					"crates/filesystem-core/src/chown_items.rs",
 					"test/fixtures/golden/chown_items.golden.json",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh"
-				]
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
 			},
 			"tsSurface": "src/handlers/chown-items.ts",
 			"rustSurface": "crates/filesystem-core/src/chown_items.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/chown_items.golden.json",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-			"notes": "Cycle64 rej-010: chown_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed."
+			"notes": "Cycle64 rej-010: chown_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
 		},
 		{
 			"id": "tool/move_items",
@@ -303,30 +286,22 @@
 				"since": "2026-07-10T10:53:32+00:00"
 			},
 			"proof": {
-				"status": "differential_green",
-				"baselineTsSha": "09773f7ecbacf1ebf0c9cc123c1be8108f9c7675",
-				"rustCandidateSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"lastComparedMainSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"mergeGroupSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"behaviorSpecHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"fixtureCorpusHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"verifiedAt": "2026-07-10T10:53:32+00:00",
-				"verificationRef": "verification/filesystem-mcp-differential-green.json",
-				"harness": "scripts/run-filesystem-mcp-differential.sh",
-				"caseCount": 36,
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
 				"dependencyGlobs": [
 					"src/handlers/replace-content.ts",
 					"test/fixtures/golden/replace_content.golden.json",
 					"crates/filesystem-core/src/replace_content.rs",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh"
-				]
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
 			},
 			"tsSurface": "src/handlers/replace-content.ts",
 			"rustSurface": "crates/filesystem-core/src/replace_content.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/replace_content.golden.json; __tests__/handlers/replace-content.success.test.ts",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-			"notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed."
+			"notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
 		},
 		{
 			"id": "tool/apply_diff",
@@ -340,31 +315,23 @@
 				"since": "2026-07-10T10:53:32+00:00"
 			},
 			"proof": {
-				"status": "differential_green",
-				"baselineTsSha": "09773f7ecbacf1ebf0c9cc123c1be8108f9c7675",
-				"rustCandidateSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"lastComparedMainSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"mergeGroupSha": "8cce53822913fe9df51907004d5cd0df2b6ea3db",
-				"behaviorSpecHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"fixtureCorpusHash": "d1410d8c97b2157666a7d9214c10cb380c13dc378132bc73e8e870c3a0ac8718",
-				"verifiedAt": "2026-07-10T10:53:32+00:00",
-				"verificationRef": "verification/filesystem-mcp-differential-green.json",
-				"harness": "scripts/run-filesystem-mcp-differential.sh",
-				"caseCount": 36,
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
 				"dependencyGlobs": [
 					"src/handlers/apply-diff.ts",
 					"test/fixtures/golden/apply_diff.golden.json",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh",
 					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				]
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
 			},
 			"tsSurface": "src/handlers/apply-diff.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
 			"rustSurface": "crates/filesystem-core/src/apply_diff.rs \u2192 crates/filesystem-cli",
 			"parityTest": "test/fixtures/golden/apply_diff.golden.json; __tests__/engine/applyDiffGoldenParity.test.ts; cargo test -p filesystem-cli --test apply_diff_golden_parity",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
 			"branch": "feat/rust-web-mcp-http-transport",
-			"notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only \u2014 authority_rust NOT claimed."
+			"notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only \u2014 authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
 		}
 	],
 	"summary": {
@@ -410,7 +377,16 @@
 			"verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
 			"notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
 		},
-		"summaryNote": "tick-010 list_files main-bound differential harness land. rej-010 promotion_hold active; authority_rust NOT claimed."
+		"summaryNote": "tick-016 expand main-bound differential: list_files + read_content + write_content. rej-010 promotion_hold active; authority_rust NOT claimed; NO prod_audit_pass.",
+		"tick016_delta": {
+			"rust_impl_verified": 0,
+			"slices": [
+				"list-files",
+				"read-content",
+				"write-content"
+			],
+			"notes": "Main-bound differential allow-list expansion. Case floors: list>=2, read>=4, write>=4. Residual caps remain for search/stat/mutations/legacy tools."
+		}
 	},
 	"priorClaims": {
 		"authority_rust": 4,
@@ -421,21 +397,22 @@
 		"reason": "rej-010 promotion freeze \u2014 0 capabilities with differential_green or canary_green proof"
 	},
 	"rej010Reaudit": {
-		"appliedAt": "2026-07-10T21:30:00Z",
+		"appliedAt": "2026-07-11T12:00:00Z",
 		"harness": "scripts/run-filesystem-mcp-differential.sh",
-		"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#filesystem_mcp_differential_matches_ts_oracle",
 		"boundedSlices": {
 			"list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
 			"read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
-			"write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle",
-			"apply-diff": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle",
-			"replace-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle",
-			"chmod-items": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle",
-			"chown-items": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle"
+			"write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle"
 		},
 		"oracle": "scripts/differential/filesystem-mcp-oracle.ts",
-		"capabilitiesWithDifferentialHarness": 8,
-		"promotionHoldActive": true
+		"capabilitiesWithDifferentialHarness": 3,
+		"promotionHoldActive": true,
+		"allowList": [
+			"list_files",
+			"read_content",
+			"write_content"
+		],
+		"notes": "tick-016 fail-closed main allow-list; other tools residual until next expansion"
 	},
 	"cycle38": {
 		"boundedSlice": "tool.list_files|tool.read_content",
@@ -473,7 +450,7 @@
 		],
 		"notes": "cycle47 rej-010: apply-diff bounded differential slice (--slice apply-diff, 5 golden cases). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
 	},
-	"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
+	"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice all",
 	"verificationRef": "verification/filesystem-mcp-differential-green.json",
 	"cycle50Slice": "apply-diff \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
 	"cycle51Slice": "list-files \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice list-files",
@@ -583,25 +560,23 @@
 		"since": "2026-07-10T10:53:32+00:00"
 	},
 	"differentialGreen": {
-		"status": "differential_green",
-		"verifiedAt": "2026-07-10T10:53:32+00:00",
-		"verificationRef": "verification/filesystem-mcp-differential-green.json",
-		"harnessPath": "scripts/run-filesystem-mcp-differential.sh",
-		"caseCount": 36,
-		"capabilities": [
-			"tool/apply_diff",
-			"tool/chmod_items",
-			"tool/chown_items",
-			"tool/list_files",
-			"tool/read_content",
-			"tool/replace_content",
-			"tool/write_content"
-		]
+		"status": "superseded_by_tick016_allow_list",
+		"note": "Prior 36-case multi-tool green was off dirty branch SHAs; main allow-list is list/read/write only until auditor rebinds."
 	},
 	"tick010": {
 		"boundedSlice": "list-files",
 		"status": "harness_landed_pending_main_proof",
 		"successorOf": "PR#200 (DIRTY \u2014 not merged)",
 		"notes": "Clean successor from main; list_files only; no authority_rust/ts_deleted."
+	},
+	"tick016": {
+		"boundedSlices": [
+			"list-files",
+			"read-content",
+			"write-content"
+		],
+		"status": "harness_landed_pending_main_proof",
+		"successorOf": "tick-010 list_files-only main land (#202)",
+		"notes": "Expand main differential beyond list_files. NO authority_rust/ts_deleted/prod_audit_pass."
 	}
 }

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -17,10 +17,7 @@
 			"note": "North Star ADR on disk \u2014 pending ADR PR; ADR number will equal introducing PR number per Doctrine"
 		}
 	],
-	"inventorySource": [
-		"mcp-tools",
-		"manual"
-	],
+	"inventorySource": ["mcp-tools", "manual"],
 	"inScopeBoundary": {
 		"includeGlobs": [
 			"src/**",
@@ -31,11 +28,7 @@
 			"__tests__/**",
 			"scripts/differential/**"
 		],
-		"excludeGlobs": [
-			"node_modules/**",
-			"dist/**",
-			"coverage/**"
-		]
+		"excludeGlobs": ["node_modules/**", "dist/**", "coverage/**"]
 	},
 	"capabilities": [
 		{
@@ -380,11 +373,7 @@
 		"summaryNote": "tick-016 expand main-bound differential: list_files + read_content + write_content. rej-010 promotion_hold active; authority_rust NOT claimed; NO prod_audit_pass.",
 		"tick016_delta": {
 			"rust_impl_verified": 0,
-			"slices": [
-				"list-files",
-				"read-content",
-				"write-content"
-			],
+			"slices": ["list-files", "read-content", "write-content"],
 			"notes": "Main-bound differential allow-list expansion. Case floors: list>=2, read>=4, write>=4. Residual caps remain for search/stat/mutations/legacy tools."
 		}
 	},
@@ -407,11 +396,7 @@
 		"oracle": "scripts/differential/filesystem-mcp-oracle.ts",
 		"capabilitiesWithDifferentialHarness": 3,
 		"promotionHoldActive": true,
-		"allowList": [
-			"list_files",
-			"read_content",
-			"write_content"
-		],
+		"allowList": ["list_files", "read_content", "write_content"],
 		"notes": "tick-016 fail-closed main allow-list; other tools residual until next expansion"
 	},
 	"cycle38": {
@@ -570,11 +555,7 @@
 		"notes": "Clean successor from main; list_files only; no authority_rust/ts_deleted."
 	},
 	"tick016": {
-		"boundedSlices": [
-			"list-files",
-			"read-content",
-			"write-content"
-		],
+		"boundedSlices": ["list-files", "read-content", "write-content"],
 		"status": "harness_landed_pending_main_proof",
 		"successorOf": "tick-010 list_files-only main land (#202)",
 		"notes": "Expand main differential beyond list_files. NO authority_rust/ts_deleted/prod_audit_pass."

--- a/scripts/differential/filesystem-mcp-oracle.ts
+++ b/scripts/differential/filesystem-mcp-oracle.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 /**
- * TS contract oracle for filesystem-mcp list_files differential parity (rej-010).
- * Frozen baseline: pure TypeScript list_files handler on golden corpus.
+ * TS contract oracle for filesystem-mcp differential parity (rej-010 / tick-016).
+ * Frozen baseline: pure TypeScript list_files + read_content + write_content
+ * handlers on golden corpus. Fail-closed allow-list — no silent extra tools.
  */
 import { createHash } from 'node:crypto'
 import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs'
@@ -9,6 +10,8 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { listFilesToolDefinition } from '../../src/handlers/list-files.ts'
+import { readContentToolDefinition } from '../../src/handlers/read-content.ts'
+import { writeContentToolDefinition } from '../../src/handlers/write-content.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // realpath avoids /tmp vs /private/tmp drift on macOS which breaks PROJECT_ROOT confinement.
@@ -19,6 +22,10 @@ const SCRATCH_CANDIDATE =
 mkdirSync(SCRATCH_CANDIDATE, { recursive: true })
 const SCRATCH_ROOT = realpathSync(SCRATCH_CANDIDATE)
 
+/** Fail-closed tool allow-list for main-bound differential expansion. */
+const ALLOWED_TOOLS = new Set(['list_files', 'read_content', 'write_content'] as const)
+type AllowedTool = 'list_files' | 'read_content' | 'write_content'
+
 interface ToolRouteCase {
 	id: string
 	tool: string
@@ -27,7 +34,7 @@ interface ToolRouteCase {
 
 interface GoldenCase {
 	id: string
-	tool: 'list_files'
+	tool: AllowedTool
 	input: Record<string, unknown>
 	expects?: Record<string, unknown>
 }
@@ -40,6 +47,7 @@ interface Corpus {
 	corpusVersion: number
 	corpusRoot: string
 	listReadGolden: string
+	writeContentGolden: string
 	toolRouteCases: ToolRouteCase[]
 	serverContract: {
 		name: string
@@ -53,6 +61,12 @@ export interface DifferentialCase {
 	readonly domain: 'tool' | 'toolRouteContract' | 'serverContract'
 	readonly input: Record<string, unknown>
 	readonly output: unknown
+}
+
+const TOOL_SLICE: Record<AllowedTool, string> = {
+	list_files: 'list-files',
+	read_content: 'read-content',
+	write_content: 'write-content',
 }
 
 const sortPaths = (paths: string[]) => [...paths].sort()
@@ -84,6 +98,46 @@ const normalizeListPayload = (value: unknown, prefix: string) => {
 	return value
 }
 
+const normalizeReadError = (error: string | undefined, prefix: string) => {
+	if (!error) {
+		return error
+	}
+	const match = error.match(/\(from relative path '([^']+)'\)/)
+	if (!match) {
+		return error
+	}
+	const relativePath = stripCorpusPrefix(match[1], prefix)
+	return error.replace(match[0], `(from relative path '${relativePath}')`)
+}
+
+const normalizeReadPayload = (
+	results: Array<{ path?: string; content?: string | unknown; error?: string }>,
+	prefix: string,
+) =>
+	results.map((entry) => ({
+		...entry,
+		path: stripCorpusPrefix(entry.path ?? '', prefix),
+		error: normalizeReadError(entry.error, prefix),
+	}))
+
+const normalizeWritePayload = (
+	results: Array<{
+		path?: string
+		success?: boolean
+		operation?: string
+		code?: string
+		error?: string
+	}>,
+	prefix: string,
+) =>
+	results.map((entry) => ({
+		path: entry.path ? stripCorpusPrefix(entry.path, prefix) : entry.path,
+		success: entry.success,
+		operation: entry.operation,
+		code: entry.code,
+		error: entry.error,
+	}))
+
 function fixtureCorpusHash(raw: string): string {
 	return createHash('sha256').update(raw).digest('hex')
 }
@@ -96,21 +150,64 @@ function copyCorpus(destination: string, source: string): void {
 	cpSync(source, destination, { recursive: true })
 }
 
-function scopeListFilesInput(
+function assertAllowedTool(tool: string, context: string): asserts tool is AllowedTool {
+	if (!ALLOWED_TOOLS.has(tool as AllowedTool)) {
+		throw new Error(
+			`fail-closed allow-list rejected tool "${tool}" in ${context}; allowed: ${[...ALLOWED_TOOLS].join(', ')}`,
+		)
+	}
+}
+
+function scopeToolInput(
+	tool: AllowedTool,
 	root: string,
 	input: Record<string, unknown>,
 ): Record<string, unknown> {
 	const relativeRoot = relative(REPO_ROOT, root).replace(/\\/g, '/')
-	const pathValue =
-		input.path === '.' || input.path === undefined
-			? relativeRoot
-			: join(relativeRoot, String(input.path)).replace(/\\/g, '/')
-	return { ...input, path: pathValue }
+	if (tool === 'list_files') {
+		const pathValue =
+			input.path === '.' || input.path === undefined
+				? relativeRoot
+				: join(relativeRoot, String(input.path)).replace(/\\/g, '/')
+		return { ...input, path: pathValue }
+	}
+	if (tool === 'read_content') {
+		return {
+			...input,
+			paths: (input.paths as string[]).map((entry) =>
+				join(relativeRoot, entry).replace(/\\/g, '/'),
+			),
+		}
+	}
+	// write_content
+	return {
+		items: (
+			input.items as Array<{
+				path: string
+				content: string
+				append?: boolean
+				expectedContentHash?: string
+			}>
+		).map((item) => ({
+			...item,
+			path: join(relativeRoot, item.path).replace(/\\/g, '/'),
+		})),
+	}
 }
 
-async function invokeListFiles(root: string, input: Record<string, unknown>): Promise<unknown> {
-	const scopedInput = scopeListFilesInput(root, input)
-	const response = await listFilesToolDefinition.handler(scopedInput)
+async function invokeToolHandler(
+	tool: AllowedTool,
+	root: string,
+	input: Record<string, unknown>,
+): Promise<unknown> {
+	const scopedInput = scopeToolInput(tool, root, input)
+	const handler =
+		tool === 'list_files'
+			? listFilesToolDefinition.handler
+			: tool === 'read_content'
+				? readContentToolDefinition.handler
+				: writeContentToolDefinition.handler
+	const response = await handler(scopedInput)
 	return JSON.parse(response.content[0].text)
 }
 
@@ -121,13 +218,18 @@ async function main(): Promise<void> {
 		throw new Error(`unsupported corpusVersion: ${corpus.corpusVersion}`)
 	}
 
-	// Force pure TypeScript list_files for the oracle baseline.
+	// Force pure TypeScript handlers for the oracle baseline.
 	delete process.env.FILESYSTEM_USE_RUST_WALK
+	delete process.env.FILESYSTEM_USE_RUST_CONTENT
+	delete process.env.FILESYSTEM_USE_RUST_WRITE
 	delete process.env.FILESYSTEM_USE_RUST_POLICY
 
 	const corpusSource = join(REPO_ROOT, corpus.corpusRoot)
 	const listReadManifest = JSON.parse(
 		readFileSync(join(REPO_ROOT, corpus.listReadGolden), 'utf8'),
+	) as GoldenManifest
+	const writeManifest = JSON.parse(
+		readFileSync(join(REPO_ROOT, corpus.writeContentGolden), 'utf8'),
 	) as GoldenManifest
 
 	const cases: DifferentialCase[] = []
@@ -135,6 +237,7 @@ async function main(): Promise<void> {
 	copyCorpus(listReadRoot, corpusSource)
 
 	for (const testCase of corpus.toolRouteCases) {
+		assertAllowedTool(testCase.tool, `toolRouteCases/${testCase.id}`)
 		cases.push({
 			id: testCase.id,
 			slice: 'tool-route-contract',
@@ -142,6 +245,10 @@ async function main(): Promise<void> {
 			input: { tool: testCase.tool },
 			output: { route: testCase.expect },
 		})
+	}
+
+	for (const tool of corpus.serverContract.tools) {
+		assertAllowedTool(tool, 'serverContract.tools')
 	}
 
 	const packageJson = JSON.parse(await readFile(join(REPO_ROOT, 'package.json'), 'utf8')) as {
@@ -162,19 +269,23 @@ async function main(): Promise<void> {
 
 	const listReadPrefix = corpusPrefixFor(listReadRoot)
 	for (const testCase of listReadManifest.cases) {
-		if (testCase.tool !== 'list_files') {
-			continue
-		}
-		const payload = await invokeListFiles(listReadRoot, testCase.input)
-		const normalized = normalizeListPayload(payload, listReadPrefix)
+		assertAllowedTool(testCase.tool, `listReadGolden/${testCase.id}`)
+		const payload = await invokeToolHandler(testCase.tool, listReadRoot, testCase.input)
+		const normalized =
+			testCase.tool === 'list_files'
+				? normalizeListPayload(payload, listReadPrefix)
+				: normalizeReadPayload(
+						payload as Array<{ path?: string; content?: unknown; error?: string }>,
+						listReadPrefix,
+					)
 		cases.push({
 			id: `tool-${testCase.id}`,
-			slice: 'list-files',
+			slice: TOOL_SLICE[testCase.tool],
 			domain: 'tool',
 			input: {
 				tool: testCase.tool,
 				// Rust CLI root is the isolated corpus directory; args stay
-				// corpus-relative (path: ".") so engine-relative paths match.
+				// corpus-relative so engine-relative paths match.
 				root: listReadRoot,
 				args: testCase.input,
 				isolate: false,
@@ -183,6 +294,39 @@ async function main(): Promise<void> {
 				status: 'ok',
 				engine: 'filesystem-core',
 				payload: normalized,
+			},
+		})
+	}
+
+	for (const testCase of writeManifest.cases) {
+		assertAllowedTool(testCase.tool, `writeContentGolden/${testCase.id}`)
+		const caseRoot = join(SCRATCH_ROOT, 'cases', testCase.id)
+		copyCorpus(caseRoot, corpusSource)
+		const casePrefix = corpusPrefixFor(caseRoot)
+		const payload = await invokeToolHandler(testCase.tool, caseRoot, testCase.input)
+		cases.push({
+			id: `tool-${testCase.id}`,
+			slice: TOOL_SLICE[testCase.tool],
+			domain: 'tool',
+			input: {
+				tool: testCase.tool,
+				root: caseRoot,
+				args: testCase.input,
+				isolate: true,
+			},
+			output: {
+				status: 'ok',
+				engine: 'filesystem-core',
+				payload: normalizeWritePayload(
+					payload as Array<{
+						path?: string
+						success?: boolean
+						operation?: string
+						code?: string
+						error?: string
+					}>,
+					casePrefix,
+				),
 			},
 		})
 	}

--- a/scripts/differential/fixtures/filesystem-mcp-corpus.json
+++ b/scripts/differential/fixtures/filesystem-mcp-corpus.json
@@ -2,15 +2,26 @@
 	"corpusVersion": 1,
 	"corpusRoot": "test/fixtures/golden/corpus",
 	"listReadGolden": "test/fixtures/golden/list_read.golden.json",
+	"writeContentGolden": "test/fixtures/golden/write_content.golden.json",
 	"toolRouteCases": [
 		{
 			"id": "route-list-files",
 			"tool": "list_files",
 			"expect": "RustCore"
+		},
+		{
+			"id": "route-read-content",
+			"tool": "read_content",
+			"expect": "RustCore"
+		},
+		{
+			"id": "route-write-content",
+			"tool": "write_content",
+			"expect": "RustCore"
 		}
 	],
 	"serverContract": {
 		"name": "filesystem-mcp",
-		"tools": ["list_files"]
+		"tools": ["list_files", "read_content", "write_content"]
 	}
 }

--- a/scripts/run-filesystem-mcp-differential.sh
+++ b/scripts/run-filesystem-mcp-differential.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Filesystem MCP list_files differential parity — TS contract oracle vs native Rust CLI/rmcp SSOT.
-# Slice: list-files (tick-010 main-bound land). Fail-closed: requires bun (no SKIP-as-pass).
+# Filesystem MCP differential parity — TS contract oracle vs native Rust CLI/rmcp SSOT.
+# Slices (tick-016 fail-closed allow-list): list-files | read-content | write-content | all
+# Fail-closed: requires bun (no SKIP-as-pass). Unknown --slice exits 1.
 # See PARITY-VERIFICATION-STANDARD.md, DECISION-001 / rej-010.
 set -euo pipefail
 
@@ -14,8 +15,11 @@ ORACLE_WORKSPACE="$REPO_ROOT/test/fixtures/differential-scratch"
 # Resolve /tmp → /private/tmp (macOS) so PROJECT_ROOT confinement accepts scratch paths.
 REPO_ROOT="$(cd "$REPO_ROOT" && pwd -P)"
 ORACLE_WORKSPACE="$REPO_ROOT/test/fixtures/differential-scratch"
-SLICE_FILTER="list-files"
+SLICE_FILTER="all"
 : >"$LOG"
+
+# Fail-closed allow-list of main-bound differential slices.
+ALLOWED_SLICES="all|list-files|read-content|write-content"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,9 +35,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SLICE_FILTER" in
-  all|list-files) ;;
+  all|list-files|read-content|write-content) ;;
   *)
-    echo "::error::invalid --slice value: $SLICE_FILTER (supported: list-files|all)" | tee -a "$LOG"
+    echo "::error::invalid --slice value: $SLICE_FILTER (supported: $ALLOWED_SLICES)" | tee -a "$LOG"
     exit 1
     ;;
 esac
@@ -53,7 +57,7 @@ bun run build 2>&1 | tee -a "$LOG"
 echo "--- build Rust rmcp server + CLI ---" | tee -a "$LOG"
 bun run build:rust 2>&1 | tee -a "$LOG"
 
-echo "--- TS contract oracle (list_files) ---" | tee -a "$LOG"
+echo "--- TS contract oracle (list_files + read_content + write_content) ---" | tee -a "$LOG"
 rm -rf "$ORACLE_WORKSPACE"
 mkdir -p "$ORACLE_WORKSPACE"
 FILESYSTEM_MCP_DIFF_SCRATCH="$ORACLE_WORKSPACE" \
@@ -71,21 +75,28 @@ case "$SLICE_FILTER" in
   list-files)
     run_rust_slice_test "list-files" list_files_differential_matches_ts_oracle
     ;;
+  read-content)
+    run_rust_slice_test "read-content" read_content_differential_matches_ts_oracle
+    ;;
+  write-content)
+    run_rust_slice_test "write-content" write_content_differential_matches_ts_oracle
+    ;;
   all)
     run_rust_slice_test "list-files" list_files_differential_matches_ts_oracle
-    echo "--- Rust differential test (list-files package + contracts) ---" | tee -a "$LOG"
-    FILESYSTEM_MCP_ORACLE_JSON="$ORACLE_JSON" \
-      cargo test -p filesystem-mcp-server --test filesystem_mcp_differential list_files_differential_matches_ts_oracle -- --nocapture 2>&1 | tee -a "$LOG"
+    run_rust_slice_test "read-content" read_content_differential_matches_ts_oracle
+    run_rust_slice_test "write-content" write_content_differential_matches_ts_oracle
     ;;
 esac
 
 CANDIDATE_SHA="${CANDIDATE_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
-BASELINE_TS_SHA="$(git -C "$REPO_ROOT" log -1 --format=%H -- scripts/differential src/handlers/list-files.ts test/fixtures/golden 2>/dev/null || echo unknown)"
+BASELINE_TS_SHA="$(git -C "$REPO_ROOT" log -1 --format=%H -- scripts/differential src/handlers/list-files.ts src/handlers/read-content.ts src/handlers/write-content.ts test/fixtures/golden 2>/dev/null || echo unknown)"
 RUST_SHA="$CANDIDATE_SHA"
 BEHAVIOR_SPEC_HASH="$(sha256sum "$REPO_ROOT/scripts/differential/fixtures/filesystem-mcp-corpus.json" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$REPO_ROOT/scripts/differential/fixtures/filesystem-mcp-corpus.json" | awk '{print $1}')"
 FIXTURE_CORPUS_HASH="$(jq -r '.fixtureCorpusHash' "$ORACLE_JSON")"
 CASE_COUNT="$(jq '.cases | length' "$ORACLE_JSON")"
 LIST_CASE_COUNT="$(jq '[.cases[] | select(.slice=="list-files")] | length' "$ORACLE_JSON")"
+READ_CASE_COUNT="$(jq '[.cases[] | select(.slice=="read-content")] | length' "$ORACLE_JSON")"
+WRITE_CASE_COUNT="$(jq '[.cases[] | select(.slice=="write-content")] | length' "$ORACLE_JSON")"
 
 jq -n \
   --arg verifiedAt "$(date -Iseconds)" \
@@ -96,10 +107,12 @@ jq -n \
   --arg fixtureCorpusHash "$FIXTURE_CORPUS_HASH" \
   --argjson caseCount "$CASE_COUNT" \
   --argjson listCaseCount "$LIST_CASE_COUNT" \
+  --argjson readCaseCount "$READ_CASE_COUNT" \
+  --argjson writeCaseCount "$WRITE_CASE_COUNT" \
   --arg sliceFilter "$SLICE_FILTER" \
   '{
     schemaVersion: 2,
-    slice: ("filesystem-mcp.tools.list_files|" + $sliceFilter),
+    slice: ("filesystem-mcp.tools.list_files|tools.read_content|tools.write_content|" + $sliceFilter),
     status: "differential_green",
     verifiedAt: $verifiedAt,
     lastComparedMainSha: $candidateSha,
@@ -110,14 +123,18 @@ jq -n \
     fixtureCorpusHash: $fixtureCorpusHash,
     caseCount: $caseCount,
     listFilesCaseCount: $listCaseCount,
+    readContentCaseCount: $readCaseCount,
+    writeContentCaseCount: $writeCaseCount,
     harness: "scripts/run-filesystem-mcp-differential.sh",
-    differentialTest: "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
+    differentialTest: "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle;read_content_differential_matches_ts_oracle;write_content_differential_matches_ts_oracle",
     boundedSlices: {
-      "list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle"
+      "list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
+      "read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
+      "write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle"
     },
     oracle: "scripts/differential/filesystem-mcp-oracle.ts",
     promotionPolicy: "NO_PROMOTIONS — differential_green recorded per rej-010; promotion_hold until prod_audit_pass; authority_rust NOT claimed"
   }' >"$ARTIFACT"
 
-echo "filesystem-mcp-differential: OK (slice=$SLICE_FILTER cases=$CASE_COUNT list_files=$LIST_CASE_COUNT corpus=$FIXTURE_CORPUS_HASH)" | tee -a "$LOG"
+echo "filesystem-mcp-differential: OK (slice=$SLICE_FILTER cases=$CASE_COUNT list_files=$LIST_CASE_COUNT read_content=$READ_CASE_COUNT write_content=$WRITE_CASE_COUNT corpus=$FIXTURE_CORPUS_HASH)" | tee -a "$LOG"
 echo "verification artifact: $ARTIFACT" | tee -a "$LOG"

--- a/test/fixtures/golden/list_read.golden.json
+++ b/test/fixtures/golden/list_read.golden.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
-	"source": "__tests__/handlers/list-files.test.ts",
+	"source": "__tests__/handlers/list-files.test.ts; __tests__/handlers/read-content.test.ts",
 	"corpusRoot": "test/fixtures/golden/corpus",
 	"cases": [
 		{
@@ -25,6 +25,77 @@
 			},
 			"expects": {
 				"paths": [".hidden", "alpha.txt", "nested/", "nested/beta.txt", "readme.md"]
+			}
+		},
+		{
+			"id": "read-single-file",
+			"tool": "read_content",
+			"input": {
+				"paths": ["alpha.txt"]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "alpha.txt",
+						"content": "Alpha line one\nAlpha line two\n"
+					}
+				]
+			}
+		},
+		{
+			"id": "read-multiple-files",
+			"tool": "read_content",
+			"input": {
+				"paths": ["alpha.txt", "nested/beta.txt", "readme.md"]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "alpha.txt",
+						"content": "Alpha line one\nAlpha line two\n"
+					},
+					{
+						"path": "nested/beta.txt",
+						"content": "Beta content\n"
+					},
+					{
+						"path": "readme.md",
+						"content": "# Golden corpus\n"
+					}
+				]
+			}
+		},
+		{
+			"id": "read-line-range-raw",
+			"tool": "read_content",
+			"input": {
+				"paths": ["alpha.txt"],
+				"start_line": 2,
+				"end_line": 2,
+				"format": "raw"
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "alpha.txt",
+						"content": "Alpha line two"
+					}
+				]
+			}
+		},
+		{
+			"id": "read-missing-file",
+			"tool": "read_content",
+			"input": {
+				"paths": ["missing.txt"]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "missing.txt",
+						"error_contains": "not found"
+					}
+				]
 			}
 		}
 	]

--- a/test/fixtures/golden/write_content.golden.json
+++ b/test/fixtures/golden/write_content.golden.json
@@ -1,0 +1,77 @@
+{
+	"schemaVersion": 1,
+	"source": "__tests__/handlers/write-content.test.ts",
+	"corpusRoot": "test/fixtures/golden/corpus",
+	"cases": [
+		{
+			"id": "write-new-file",
+			"tool": "write_content",
+			"input": {
+				"items": [{ "path": "new-file.txt", "content": "brand new content\n" }]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "new-file.txt",
+						"success": true,
+						"operation": "written"
+					}
+				]
+			}
+		},
+		{
+			"id": "write-overwrite",
+			"tool": "write_content",
+			"input": {
+				"items": [{ "path": "alpha.txt", "content": "replaced alpha\n" }]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "alpha.txt",
+						"success": true,
+						"operation": "written"
+					}
+				]
+			}
+		},
+		{
+			"id": "write-append",
+			"tool": "write_content",
+			"input": {
+				"items": [
+					{
+						"path": "alpha.txt",
+						"content": "appended line\n",
+						"append": true
+					}
+				]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "alpha.txt",
+						"success": true,
+						"operation": "appended"
+					}
+				]
+			}
+		},
+		{
+			"id": "write-nested-path",
+			"tool": "write_content",
+			"input": {
+				"items": [{ "path": "nested/gamma.txt", "content": "nested write\n" }]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "nested/gamma.txt",
+						"success": true,
+						"operation": "written"
+					}
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Expand main-bound fail-closed differential beyond `list_files` for the next highest-value RustCore tools already implemented on main:

| Tool | Slice | Cases |
|------|-------|-------|
| `list_files` | list-files | 2 |
| `read_content` | read-content | 4 |
| `write_content` | write-content | 4 |
| tool-route + server-contract | — | 4 |
| **Total oracle cases** | | **14** |

## Why these tools

- Weight-4 `rust_impl` on main with MCP-shaped CLI envelopes (`cli_bridge` → `filesystem-cli`)
- Explicit `ToolRoute::RustCore` (unlike apply_diff/chmod/etc. which remain `LegacyOptIn` on main)
- Prior dirty-branch harness existed; this lands a clean main-bound allow-list expansion after tick-010 list_files-only land

## Fail-closed allow-list

- `--slice` accepts only: `all|list-files|read-content|write-content` (unknown → exit 1)
- Oracle rejects any tool outside `{list_files, read_content, write_content}`
- CI runs `--slice all` with case floors (list≥2, read≥4, write≥4)

## Residual caps (still not main-bound)

search_files, stat_items, delete/create/move/copy, replace_content, apply_diff, chmod/chown, transport/web-mcp-http

## Policy

- **NO** `authority_rust` / `ts_deleted` / `prod_audit_pass` claims
- `promotion_hold` remains (rej-010); auditor follows

## Local proof

```
filesystem-mcp-differential: OK (slice=all cases=14 list_files=2 read_content=4 write_content=4)
```

Packet: `FILESYSTEM-MCP-EXPAND-DIFF-MAIN-TICK016`