### PR TITLE
chore(release): bump to 0.7.2 multi-arch republish from tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2
+
+### Patch Changes
+
+- Republish multi-arch natives from main tip including search_files MCP Success envelope fix (cli_bridge LegacyToolSuccessEnvelope) and expanded main differential (search_files + stat_items).
+
 ## 0.7.1
 
 ### Patch Changes

--- a/bun.lock
+++ b/bun.lock
@@ -30,10 +30,10 @@
         "vitest": "^3.1.1",
       },
       "optionalDependencies": {
-        "@sylphx/filesystem-mcp-darwin-arm64": "0.7.1",
-        "@sylphx/filesystem-mcp-darwin-x64": "0.7.1",
-        "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.1",
-        "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.1",
+        "@sylphx/filesystem-mcp-darwin-arm64": "0.7.2",
+        "@sylphx/filesystem-mcp-darwin-x64": "0.7.2",
+        "@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.2",
+        "@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.2",
       },
     },
   },
@@ -323,14 +323,6 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sylphx/biome-config": ["@sylphx/biome-config@0.4.1", "", { "peerDependencies": { "@biomejs/biome": "^2.0.0" } }, "sha512-yNdrXKcnhrXK+OB2WLEJix6cryj3PME5DbKpGFMJGA6/B1/+mpk2ChKiohifrf956FKQ3JTAqhLhZfY7lu18yA=="],
-
-    "@sylphx/filesystem-mcp-darwin-arm64": ["@sylphx/filesystem-mcp-darwin-arm64@0.7.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-J2Ckvhx++lUlffOZop+w3Do4Gw3I4/nTEhkBRRj5/mP649SX9kahSLJLkiK/gHYNUfXVJBDzE8DSPp2NRfDYvg=="],
-
-    "@sylphx/filesystem-mcp-darwin-x64": ["@sylphx/filesystem-mcp-darwin-x64@0.7.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-dqbUDRkZhRpD0oo0SM8xbK3hZAeNqMo7PaDmCURw3nNVN9OEnT4EvQAVH2XMkrU2xDPXs9VIRkrV08EWCUVEHA=="],
-
-    "@sylphx/filesystem-mcp-linux-arm64-gnu": ["@sylphx/filesystem-mcp-linux-arm64-gnu@0.7.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-2MpDxYFMHggE7ss+gG+ZdF8N0wSG9uK9pO+ZfDPtrp9whWb7lIH4QXZmt6VxanEwmPnWNSO1Fn+jSzMjNn0EPw=="],
-
-    "@sylphx/filesystem-mcp-linux-x64-gnu": ["@sylphx/filesystem-mcp-linux-x64-gnu@0.7.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cnbwWaByWtw5fyslp/XBEXiD0V+vzBPXObfk7oG2nbk1C1nd/9TsLPxFnSgZ69yBUA8b8ojWRsVmEOYuo/Rm7Q=="],
 
     "@sylphx/tsconfig": ["@sylphx/tsconfig@0.3.1", "", {}, "sha512-S7JAV9OEt3LUChz1jmFMG2coJGYdmSF+n4x6lPK9JziykFCvS37d4G5uoBS2kWVW4grnZa+WRmAtZkE9oMFi0Q=="],
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sylphx/filesystem-mcp-darwin-arm64",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "Filesystem MCP server native binary for darwin-arm64",
 	"os": [
 		"darwin"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sylphx/filesystem-mcp-darwin-x64",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "Filesystem MCP server native binary for darwin-x64",
 	"os": [
 		"darwin"

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sylphx/filesystem-mcp-linux-arm64-gnu",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "Filesystem MCP server native binary for linux-arm64-gnu",
 	"os": [
 		"linux"

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sylphx/filesystem-mcp-linux-x64-gnu",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "Filesystem MCP server native binary for linux-x64-gnu",
 	"os": [
 		"linux"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sylphx/filesystem-mcp",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "An MCP server providing filesystem tools relative to a project root.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -119,9 +119,9 @@
 	},
 	"packageManager": "bun@1.3.12",
 	"optionalDependencies": {
-		"@sylphx/filesystem-mcp-darwin-arm64": "0.7.1",
-		"@sylphx/filesystem-mcp-darwin-x64": "0.7.1",
-		"@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.1",
-		"@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.1"
+		"@sylphx/filesystem-mcp-darwin-arm64": "0.7.2",
+		"@sylphx/filesystem-mcp-darwin-x64": "0.7.2",
+		"@sylphx/filesystem-mcp-linux-x64-gnu": "0.7.2",
+		"@sylphx/filesystem-mcp-linux-arm64-gnu": "0.7.2"
 	}
 }


### PR DESCRIPTION
## Summary

- Bump `@sylphx/filesystem-mcp` and all platform optionalDependencies to **0.7.2**
- Enables Release multi-arch publish from main tip so consumer npm `gitHead` includes the search_files MCP envelope fix landed in #206 (`9e28446`)
- No runtime code changes — version + CHANGELOG + lock only

## Packet

`FILESYSTEM-MCP-PUBLISH-TIP-TICK023` — remediate deployDigest dual-bind failure from tick-023 re-audit (`republishRequired`: npm@0.7.1 still at `71bfe911`).

## Test plan

- [ ] CI Validate + Native multi-arch green
- [ ] Merge → Release publishes 0.7.2 + 4 platform packages
- [ ] npm `gitHead` == main tip after merge
- [ ] Darwin arm64 consumer smoke (optionalDep Mach-O + search_files MCP path)

## Explicit non-claims

- Not `prod_audit_pass`
- No capability / ledger promotion / `ts_deleted` / FCP advance