### PR TITLE
feat(mcp): native delete_items + differential harness (TICK029)

### DIFF
--- a/__tests__/differentialHarness.matrix.test.ts
+++ b/__tests__/differentialHarness.matrix.test.ts
@@ -92,7 +92,7 @@ describe('filesystem-mcp differential harness (rej-010 tick-022 search+stat expa
 			serverContract: { tools: string[] }
 		}
 
-		const allowed = new Set(['list_files', 'read_content', 'write_content', 'search_files', 'stat_items'])
+		const allowed = new Set(['list_files', 'read_content', 'write_content', 'search_files', 'stat_items', 'delete_items'])
 		for (const route of corpus.toolRouteCases) {
 			expect(allowed.has(route.tool)).toBe(true)
 			expect(route.expect).toBe('RustCore')

--- a/__tests__/differentialHarness.matrix.test.ts
+++ b/__tests__/differentialHarness.matrix.test.ts
@@ -92,7 +92,14 @@ describe('filesystem-mcp differential harness (rej-010 tick-022 search+stat expa
 			serverContract: { tools: string[] }
 		}
 
-		const allowed = new Set(['list_files', 'read_content', 'write_content', 'search_files', 'stat_items', 'delete_items'])
+		const allowed = new Set([
+			'list_files',
+			'read_content',
+			'write_content',
+			'search_files',
+			'stat_items',
+			'delete_items',
+		])
 		for (const route of corpus.toolRouteCases) {
 			expect(allowed.has(route.tool)).toBe(true)
 			expect(route.expect).toBe('RustCore')

--- a/crates/filesystem-cli/src/legacy_runtime.rs
+++ b/crates/filesystem-cli/src/legacy_runtime.rs
@@ -168,7 +168,7 @@ pub fn is_native_rust_engine_request(tool: &str, input: &Value) -> bool {
         | "record_write_audit"
         | "read_content"
         | "write_content"
-        | "stat_items" => true,
+        | "stat_items" | "delete_items" => true,
         _ => false,
     }
 }

--- a/crates/filesystem-cli/src/main.rs
+++ b/crates/filesystem-cli/src/main.rs
@@ -8,7 +8,7 @@ use filesystem_core::search::SearchMatch;
 use filesystem_core::walk::ListFilesResult;
 use filesystem_core::{
     append_audit_batch_with_limit, content_hash, read_content, resolve_path, stat_items,
-    write_content, PolicyErrorCode, ReadContentOptions, ReadFormat, WriteItem, ENGINE_NAME,
+    delete_items, write_content, PolicyErrorCode, ReadContentOptions, ReadFormat, WriteItem, ENGINE_NAME,
     ENGINE_VERSION, DEFAULT_MAX_ROLLBACK_BYTES,
 };
 use serde::{Deserialize, Serialize};
@@ -429,6 +429,41 @@ fn handle_stat_items(
     })
 }
 
+
+fn handle_delete_items(
+    input: &serde_json::Value,
+) -> Result<LegacyToolSuccessEnvelope, ErrorEnvelope> {
+    let root = project_root_from_input(input);
+    let paths = input
+        .get("paths")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if paths.is_empty() {
+        return Err(ErrorEnvelope {
+            status: "error",
+            code: "INVALID_PARAMS".into(),
+            message: "paths is required".into(),
+            next_action: "Pass a non-empty array of relative paths.".into(),
+        });
+    }
+
+    let results = delete_items(&root, &paths);
+    Ok(LegacyToolSuccessEnvelope {
+        status: "ok",
+        engine: ENGINE_NAME,
+        version: ENGINE_VERSION,
+        tool: "delete_items".into(),
+        result: wrap_mcp_text_payload(&serde_json::to_value(results).expect("serialize")),
+    })
+}
+
 fn handle_resolve_path(input: &serde_json::Value) -> Result<SuccessEnvelope, ErrorEnvelope> {
     let relative_path = input
         .get("relative_path")
@@ -517,11 +552,15 @@ fn main() {
                 Ok(success) => serde_json::to_string(&success).expect("serialize"),
                 Err(error) => serde_json::to_string(&error).expect("serialize"),
             },
+            "delete_items" => match handle_delete_items(&request.input) {
+                Ok(success) => serde_json::to_string(&success).expect("serialize"),
+                Err(error) => serde_json::to_string(&error).expect("serialize"),
+            },
             other => serde_json::to_string(&ErrorEnvelope {
                 status: "error",
                 code: "UNSUPPORTED_TOOL".into(),
                 message: format!("Unsupported native tool: {other}"),
-                next_action: "Use resolve_path, search_files, list_files, content_hash, record_write_audit, read_content, write_content, or stat_items.".into(),
+                next_action: "Use resolve_path, search_files, list_files, content_hash, record_write_audit, read_content, write_content, stat_items, or delete_items.".into(),
             })
             .expect("serialize"),
         }

--- a/crates/filesystem-core/src/content.rs
+++ b/crates/filesystem-core/src/content.rs
@@ -74,6 +74,17 @@ impl Default for ReadContentOptions {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteItemsResult {
+    pub path: String,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct WriteItem {
     pub path: String,
@@ -398,3 +409,100 @@ mod tests {
         assert!(stats[0].stats.as_ref().is_some_and(|entry| entry.is_file));
     }
 }
+
+pub fn delete_items(root: &Path, paths: &[String]) -> Vec<DeleteItemsResult> {
+    paths
+        .iter()
+        .map(|relative| delete_single_path(root, relative))
+        .collect()
+}
+
+fn delete_single_path(root: &Path, relative_path: &str) -> DeleteItemsResult {
+    let path_output = normalize_display_path(relative_path);
+    let resolved = match resolve_path(relative_path, root) {
+        Ok(path) => path,
+        Err(error) => {
+            return DeleteItemsResult {
+                path: path_output,
+                success: false,
+                note: None,
+                error: Some(error.message),
+            };
+        }
+    };
+
+    if paths_equal(&resolved, root) {
+        return DeleteItemsResult {
+            path: path_output,
+            success: false,
+            note: None,
+            error: Some("Deleting the project root is not allowed.".into()),
+        };
+    }
+
+    let meta = match fs::symlink_metadata(&resolved) {
+        Ok(meta) => meta,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return DeleteItemsResult {
+                path: path_output,
+                success: true,
+                note: Some("Path not found, nothing to delete"),
+                error: None,
+            };
+        }
+        Err(error) => {
+            return delete_io_error(path_output, relative_path, error);
+        }
+    };
+
+    let result = if meta.is_dir() {
+        fs::remove_dir_all(&resolved)
+    } else {
+        fs::remove_file(&resolved)
+    };
+
+    match result {
+        Ok(()) => DeleteItemsResult {
+            path: path_output,
+            success: true,
+            note: None,
+            error: None,
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => DeleteItemsResult {
+            path: path_output,
+            success: true,
+            note: Some("Path not found, nothing to delete"),
+            error: None,
+        },
+        Err(error) => delete_io_error(path_output, relative_path, error),
+    }
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => a == b,
+    }
+}
+
+fn delete_io_error(path_output: String, relative_path: &str, error: std::io::Error) -> DeleteItemsResult {
+    let message = match error.kind() {
+        std::io::ErrorKind::PermissionDenied => {
+            format!("Permission denied deleting {relative_path}")
+        }
+        _ => format!(
+            "Failed to delete {relative_path}: {error} (code: {})",
+            error
+                .raw_os_error()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "unknown".into())
+        ),
+    };
+    DeleteItemsResult {
+        path: path_output,
+        success: false,
+        note: None,
+        error: Some(message),
+    }
+}
+

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -8,8 +8,8 @@ pub mod walk;
 pub use walk::format_entry_stats;
 
 pub use content::{
-    read_content, stat_items, write_content, ReadContentOptions, ReadContentResult, ReadFormat,
-    StatItemResult, WriteContentResult, WriteItem, CONTENT_ROUTE,
+    delete_items, read_content, stat_items, write_content, DeleteItemsResult, ReadContentOptions,
+    ReadContentResult, ReadFormat, StatItemResult, WriteContentResult, WriteItem, CONTENT_ROUTE,
 };
 pub use audit::{
     append_audit_batch, append_audit_batch_with_limit, content_hash, generate_operation_id,

--- a/crates/filesystem-mcp-server/src/tool_routes.rs
+++ b/crates/filesystem-mcp-server/src/tool_routes.rs
@@ -15,9 +15,9 @@ pub fn route_for_tool(tool: &str) -> Option<ToolRoute> {
         | "record_write_audit"
         | "read_content"
         | "write_content"
-        | "stat_items" => Some(ToolRoute::RustCore),
-        "delete_items"
-        | "create_directories"
+        | "stat_items"
+        | "delete_items" => Some(ToolRoute::RustCore),
+        "create_directories"
         | "chmod_items"
         | "chown_items"
         | "move_items"
@@ -39,5 +39,6 @@ mod tests {
         assert_eq!(route_for_tool("read_content"), Some(ToolRoute::RustCore));
         assert_eq!(route_for_tool("write_content"), Some(ToolRoute::RustCore));
         assert_eq!(route_for_tool("stat_items"), Some(ToolRoute::RustCore));
+        assert_eq!(route_for_tool("delete_items"), Some(ToolRoute::RustCore));
     }
 }

--- a/crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs
+++ b/crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs
@@ -7,6 +7,7 @@
 //! - `write_content_differential_matches_ts_oracle` — S2 mutation path (4 cases)
 //! - `search_files_differential_matches_ts_oracle` — S1 search path (4 cases)
 //! - `stat_items_differential_matches_ts_oracle` — S1 stat path (3 cases)
+//! - `delete_items_differential_matches_ts_oracle` — S2 delete path (2 cases)
 //! See scripts/run-filesystem-mcp-differential.sh.
 
 use filesystem_mcp_server::cli_bridge;
@@ -24,8 +25,9 @@ const READ_CONTENT_SLICE: &str = "read-content";
 const WRITE_CONTENT_SLICE: &str = "write-content";
 const SEARCH_FILES_SLICE: &str = "search-files";
 const STAT_ITEMS_SLICE: &str = "stat-items";
+const DELETE_ITEMS_SLICE: &str = "delete-items";
 
-/// Serialize tool cases that mutate isolated corpus trees (write_content).
+/// Serialize tool cases that mutate isolated corpus trees (write_content / delete_items).
 static TOOL_CASE_LOCK: Mutex<()> = Mutex::new(());
 
 fn repo_root() -> PathBuf {
@@ -265,12 +267,41 @@ fn normalize_stat_payload(payload: &Value) -> Value {
     Value::Array(entries)
 }
 
+fn normalize_delete_payload(payload: &Value) -> Value {
+    let entries = payload
+        .as_array()
+        .expect("delete_items array payload")
+        .iter()
+        .map(|entry| {
+            let object = entry.as_object().expect("delete_items result object");
+            let mut normalized = serde_json::Map::new();
+            normalized.insert(
+                "path".into(),
+                object.get("path").cloned().unwrap_or(Value::Null),
+            );
+            normalized.insert(
+                "success".into(),
+                object.get("success").cloned().unwrap_or(Value::Null),
+            );
+            if let Some(note) = object.get("note").filter(|value| !value.is_null()) {
+                normalized.insert("note".into(), note.clone());
+            }
+            if let Some(error) = object.get("error").filter(|value| !value.is_null()) {
+                normalized.insert("error".into(), error.clone());
+            }
+            Value::Object(normalized)
+        })
+        .collect::<Vec<_>>();
+    Value::Array(entries)
+}
+
 fn normalize_tool_payload(tool: &str, payload: Value) -> Value {
     match tool {
         "list_files" => sorted_string_array(&payload),
         "write_content" => normalize_write_payload(&payload),
         "search_files" => normalize_search_payload(&payload),
         "stat_items" => normalize_stat_payload(&payload),
+        "delete_items" => normalize_delete_payload(&payload),
         _ => payload,
     }
 }
@@ -399,6 +430,10 @@ fn assert_slice_metadata(case: &OracleCase) {
             assert_eq!(case.domain, "tool");
             assert_eq!(case.input["tool"].as_str(), Some("stat_items"));
         }
+        DELETE_ITEMS_SLICE => {
+            assert_eq!(case.domain, "tool");
+            assert_eq!(case.input["tool"].as_str(), Some("delete_items"));
+        }
         "tool-route-contract" => assert_eq!(case.domain, "toolRouteContract"),
         "server-contract" => assert_eq!(case.domain, "serverContract"),
         other => panic!("unknown slice {other} for case {}", case.id),
@@ -464,3 +499,9 @@ fn search_files_differential_matches_ts_oracle() {
 fn stat_items_differential_matches_ts_oracle() {
     run_bounded_slice(STAT_ITEMS_SLICE, 3);
 }
+
+#[test]
+fn delete_items_differential_matches_ts_oracle() {
+    run_bounded_slice(DELETE_ITEMS_SLICE, 2);
+}
+

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -1,623 +1,677 @@
 {
-	"schemaVersion": 3,
-	"repo": "SylphxAI/filesystem-mcp",
-	"repoLedgerPath": "docs/specs/migration-ledger.json",
-	"lockedAt": "2026-07-09T22:00:00Z",
-	"programSpec": {
-		"id": "rust-first-fleet-migration",
-		"controlPlaneRepo": "SylphxAI/rust-first-fleet-control-plane",
-		"programSpecPath": "PROGRAM-SPEC.json",
-		"completionStandard": "COMPLETION-STANDARD.md",
-		"parityStandard": "PARITY-VERIFICATION-STANDARD.md"
-	},
-	"adrRefs": [
-		{
-			"path": "docs/adr/ADR-PROPOSED-fleet-filesystem-mcp-rust-north-star.md",
-			"status": "proposed",
-			"note": "North Star ADR on disk — pending ADR PR; ADR number will equal introducing PR number per Doctrine"
-		}
-	],
-	"inventorySource": ["mcp-tools", "manual"],
-	"inScopeBoundary": {
-		"includeGlobs": [
-			"src/**",
-			"crates/filesystem-core/**",
-			"crates/filesystem-cli/**",
-			"crates/filesystem-mcp-server/**",
-			"bin/**",
-			"__tests__/**",
-			"scripts/differential/**"
-		],
-		"excludeGlobs": ["node_modules/**", "dist/**", "coverage/**"]
-	},
-	"capabilities": [
-		{
-			"id": "transport/web-mcp-http",
-			"domain": "transport",
-			"weight": 5,
-			"state": "rust_impl",
-			"rustSurface": "crates/filesystem-mcp-server/src/http_transport.rs (rmcp StreamableHttpService)",
-			"parityTest": "__tests__/transport/httpTransport.matrix.test.ts",
-			"prodProbe": "benchmark:release-gate → mcp:rust_web_http_transport"
-		},
-		{
-			"id": "transport/stdio-rust-rmcp",
-			"domain": "transport",
-			"weight": 4,
-			"state": "rust_impl",
-			"rustSurface": "crates/filesystem-mcp-server/src/main.rs (rmcp::transport::stdio())",
-			"prodProbe": "benchmark:release-gate → mcp:rust_adapter_default"
-		},
-		{
-			"id": "transport/stdio-ts-adapter",
-			"domain": "transport",
-			"weight": 4,
-			"state": "ts_only",
-			"tsSurface": "src/index.ts",
-			"notes": "Opt-in TS stdio MCP adapter (FILESYSTEM_MCP_TRANSPORT=ts); retained until ts_deleted."
-		},
-		{
-			"id": "tool/list_files",
-			"domain": "mcp-tools",
-			"weight": 4,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: main-bound multi-tool differential (list/read/write) — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-11T00:00:00+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
-				"dependencyGlobs": [
-					"src/handlers/list-files.ts",
-					"src/engine/rust-walk.ts",
-					"crates/filesystem-core/src/walk.rs",
-					"crates/filesystem-cli/src/main.rs",
-					"crates/filesystem-mcp-server/src/cli_bridge.rs",
-					"test/fixtures/golden/list_read.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh",
-					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				]
-			},
-			"tsSurface": "src/handlers/list-files.ts; src/engine/rust-walk.ts (opt-out via FILESYSTEM_USE_RUST_WALK=ts)",
-			"rustSurface": "crates/filesystem-core/src/walk.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice list-files",
-			"branch": "feat/expand-diff-main-tick016",
-			"notes": "tick-016: main-bound differential remains list_files + expanded siblings. rust_impl ONLY — authority_rust NOT claimed (rej-010)."
-		},
-		{
-			"id": "tool/search_files",
-			"domain": "mcp-tools",
-			"weight": 4,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: main-bound search_files differential harness (tick-022) — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-11T12:00:00+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "scripts/run-filesystem-mcp-differential.sh --slice search-files",
-				"dependencyGlobs": [
-					"src/handlers/search-files.ts",
-					"src/engine/rust-search.ts",
-					"crates/filesystem-core/src/search.rs",
-					"crates/filesystem-cli/src/main.rs",
-					"crates/filesystem-mcp-server/src/cli_bridge.rs",
-					"test/fixtures/golden/search_stat.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh",
-					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				]
-			},
-			"tsSurface": "src/handlers/search-files.ts; src/engine/rust-search.ts (opt-in via FILESYSTEM_USE_RUST_SEARCH=1)",
-			"rustSurface": "crates/filesystem-core/src/search.rs → crates/filesystem-cli (MCP CallToolResult envelope)",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#search_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice search-files",
-			"branch": "feat/expand-diff-search-stat-tick022",
-			"notes": "tick-022: main-bound search_files differential (4 golden cases) + CLI MCP envelope fix (LegacyToolSuccessEnvelope). rust_impl ONLY — authority_rust NOT claimed."
-		},
-		{
-			"id": "tool/read_content",
-			"domain": "mcp-tools",
-			"weight": 4,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: main-bound read_content differential harness (tick-016) — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-11T00:00:00+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "scripts/run-filesystem-mcp-differential.sh --slice read-content",
-				"dependencyGlobs": [
-					"src/handlers/read-content.ts",
-					"src/engine/rust-content.ts",
-					"crates/filesystem-core/src/content.rs",
-					"crates/filesystem-cli/src/main.rs",
-					"crates/filesystem-mcp-server/src/cli_bridge.rs",
-					"test/fixtures/golden/list_read.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh",
-					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				]
-			},
-			"tsSurface": "src/handlers/read-content.ts; src/engine/rust-content.ts (opt-out via FILESYSTEM_USE_RUST_CONTENT=ts)",
-			"rustSurface": "crates/filesystem-core/src/content.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice read-content",
-			"branch": "feat/expand-diff-main-tick016",
-			"notes": "tick-016: main-bound read_content differential (4 golden cases). rust_impl ONLY — authority_rust NOT claimed. Stale pre-main differential_green cleared."
-		},
-		{
-			"id": "tool/write_content",
-			"domain": "mcp-tools",
-			"weight": 4,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: main-bound write_content differential harness (tick-016) — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-11T00:00:00+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "scripts/run-filesystem-mcp-differential.sh --slice write-content",
-				"dependencyGlobs": [
-					"src/handlers/write-content.ts",
-					"src/engine/rust-write.ts",
-					"crates/filesystem-core/src/content.rs",
-					"crates/filesystem-cli/src/main.rs",
-					"crates/filesystem-mcp-server/src/cli_bridge.rs",
-					"test/fixtures/golden/write_content.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh",
-					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				]
-			},
-			"tsSurface": "src/handlers/write-content.ts; src/engine/rust-write.ts (opt-out via FILESYSTEM_USE_RUST_WRITE=ts)",
-			"rustSurface": "crates/filesystem-core/src/content.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/write_content.golden.json; __tests__/engine/writeContentGoldenParity.test.ts; cargo test -p filesystem-cli --test write_content_golden_parity",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice write-content",
-			"branch": "feat/expand-diff-main-tick016",
-			"notes": "tick-016: main-bound write_content differential (4 golden cases). rust_impl ONLY — authority_rust NOT claimed. Stale pre-main differential_green cleared."
-		},
-		{
-			"id": "tool/stat_items",
-			"domain": "mcp-tools",
-			"weight": 4,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: main-bound stat_items differential harness (tick-022) — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-11T12:00:00+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "scripts/run-filesystem-mcp-differential.sh --slice stat-items",
-				"dependencyGlobs": [
-					"src/handlers/stat-items.ts",
-					"crates/filesystem-core/src/content.rs",
-					"crates/filesystem-cli/src/main.rs",
-					"crates/filesystem-mcp-server/src/cli_bridge.rs",
-					"test/fixtures/golden/search_stat.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh",
-					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				]
-			},
-			"tsSurface": "src/handlers/stat-items.ts",
-			"rustSurface": "crates/filesystem-core/src/content.rs → crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#stat_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice stat-items",
-			"branch": "feat/expand-diff-search-stat-tick022",
-			"notes": "tick-022: main-bound stat_items differential (3 golden cases). rust_impl ONLY — authority_rust NOT claimed."
-		},
-		{
-			"id": "tool/delete_items",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"tsSurface": "src/handlers/delete-items.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs → crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-		},
-		{
-			"id": "tool/create_directories",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"tsSurface": "src/handlers/create-directories.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs → crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-		},
-		{
-			"id": "tool/chmod_items",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-				"dependencyGlobs": [
-					"src/handlers/chmod-items.ts",
-					"crates/filesystem-core/src/chmod_items.rs",
-					"test/fixtures/golden/chmod_items.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh"
-				],
-				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-			},
-			"tsSurface": "src/handlers/chmod-items.ts",
-			"rustSurface": "crates/filesystem-core/src/chmod_items.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/chmod_items.golden.json; __tests__/handlers/chmod-items.test.ts",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-			"notes": "Cycle63 rej-010: chmod_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual — not in main allow-list."
-		},
-		{
-			"id": "tool/chown_items",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-				"dependencyGlobs": [
-					"src/handlers/chown-items.ts",
-					"crates/filesystem-core/src/chown_items.rs",
-					"test/fixtures/golden/chown_items.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh"
-				],
-				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-			},
-			"tsSurface": "src/handlers/chown-items.ts",
-			"rustSurface": "crates/filesystem-core/src/chown_items.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/chown_items.golden.json",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-			"notes": "Cycle64 rej-010: chown_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual — not in main allow-list."
-		},
-		{
-			"id": "tool/move_items",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"tsSurface": "src/handlers/move-items.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs → crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-		},
-		{
-			"id": "tool/copy_items",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"tsSurface": "src/handlers/copy-items.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs → crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-		},
-		{
-			"id": "tool/replace_content",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-				"dependencyGlobs": [
-					"src/handlers/replace-content.ts",
-					"test/fixtures/golden/replace_content.golden.json",
-					"crates/filesystem-core/src/replace_content.rs",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh"
-				],
-				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-			},
-			"tsSurface": "src/handlers/replace-content.ts",
-			"rustSurface": "crates/filesystem-core/src/replace_content.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/replace_content.golden.json; __tests__/handlers/replace-content.success.test.ts",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-			"notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual — not in main allow-list."
-		},
-		{
-			"id": "tool/apply_diff",
-			"domain": "mcp-tools",
-			"weight": 3,
-			"state": "rust_impl",
-			"promotionHold": {
-				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs — promotion_hold until prod_audit_pass",
-				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
-			},
-			"proof": {
-				"status": "missing",
-				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-				"dependencyGlobs": [
-					"src/handlers/apply-diff.ts",
-					"test/fixtures/golden/apply_diff.golden.json",
-					"scripts/differential/**",
-					"scripts/run-filesystem-mcp-differential.sh",
-					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-				],
-				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-			},
-			"tsSurface": "src/handlers/apply-diff.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
-			"rustSurface": "crates/filesystem-core/src/apply_diff.rs → crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/apply_diff.golden.json; __tests__/engine/applyDiffGoldenParity.test.ts; cargo test -p filesystem-cli --test apply_diff_golden_parity",
-			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-			"branch": "feat/rust-web-mcp-http-transport",
-			"notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only — authority_rust NOT claimed. tick-016: residual — not in main allow-list."
-		}
-	],
-	"summary": {
-		"total": 16,
-		"ts_only": 1,
-		"contracted": 0,
-		"rust_impl": 15,
-		"parity_proven": 7,
-		"authority_rust": 0,
-		"ts_deleted": 0,
-		"proof_missing": 0,
-		"completion_progress": 0.0,
-		"authority_progress": 0.0,
-		"verified_authority_progress": 0,
-		"weighted_progress": 0.3445,
-		"cycle50_delta": {
-			"rust_impl_verified": 1,
-			"slice": "apply-diff",
-			"verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
-			"notes": "rej-010 rust_impl ONLY — cycle50 highest-value unimplemented slice: apply-diff bounded differential (5 golden cases)"
-		},
-		"cycle51_delta": {
-			"rust_impl_verified": 1,
-			"slice": "list-files",
-			"verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
-			"notes": "rej-010 rust_impl ONLY — cycle51 next highest-value slice: list-files bounded differential (2 golden cases)"
-		},
-		"cycle62_delta": {
-			"rust_impl_verified": 1,
-			"slice": "replace-content",
-			"verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
-			"notes": "rej-010 rust_impl ONLY — cycle62 next ts_only slice: replace-content bounded differential (2 golden cases)"
-		},
-		"cycle63_delta": {
-			"rust_impl_verified": 1,
-			"slice": "chmod-items",
-			"verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
-			"notes": "rej-010 rust_impl ONLY — cycle63 next ts_only slice: chmod-items bounded differential (2 golden cases)"
-		},
-		"cycle64_delta": {
-			"rust_impl_verified": 1,
-			"slice": "chown-items",
-			"verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
-			"notes": "rej-010 rust_impl ONLY — cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
-		},
-		"summaryNote": "tick-016 expand main-bound differential: list_files + read_content + write_content. rej-010 promotion_hold active; authority_rust NOT claimed; NO prod_audit_pass.",
-		"tick016_delta": {
-			"rust_impl_verified": 0,
-			"slices": ["list-files", "read-content", "write-content"],
-			"notes": "Main-bound differential allow-list expansion. Case floors: list>=2, read>=4, write>=4. Residual caps remain for search/stat/mutations/legacy tools."
-		}
-	},
-	"priorClaims": {
-		"authority_rust": 4,
-		"rust_impl": 8,
-		"completion_progress": 0.0,
-		"authority_progress": 0.25,
-		"revertedAt": "2026-07-10T21:30:00Z",
-		"reason": "rej-010 promotion freeze — 0 capabilities with differential_green or canary_green proof"
-	},
-	"rej010Reaudit": {
-		"appliedAt": "2026-07-11T12:00:00Z",
-		"harness": "scripts/run-filesystem-mcp-differential.sh",
-		"boundedSlices": {
-			"list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
-			"read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
-			"write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle"
-		},
-		"oracle": "scripts/differential/filesystem-mcp-oracle.ts",
-		"capabilitiesWithDifferentialHarness": 3,
-		"promotionHoldActive": true,
-		"allowList": ["list_files", "read_content", "write_content"],
-		"notes": "tick-016 fail-closed main allow-list; other tools residual until next expansion"
-	},
-	"cycle38": {
-		"boundedSlice": "tool.list_files|tool.read_content",
-		"status": "harness_landed_disk",
-		"evidenceRef": "/tmp/grok-goal-729a939ec6e2/implementer/cycle38-mcp/cycle38-mcp.json",
-		"deliverables": [
-			"docs/specs/filesystem-mcp-parity-slice.json",
-			"__tests__/differentialHarness.matrix.test.ts",
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-		],
-		"notes": "cycle38 rej-010: list-read bounded differential harness + matrix gate confirmed on disk. rust_impl only — proof.status missing until differential_green at bound SHAs."
-	},
-	"cycle43": {
-		"boundedSlice": "tool.write_content",
-		"status": "harness_landed_disk",
-		"deliverables": [
-			"docs/specs/filesystem-mcp-parity-slice.json",
-			"__tests__/differentialHarness.matrix.test.ts",
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-		],
-		"notes": "cycle43 rej-010: write-content bounded differential slice (--slice write-content). rust_impl only — proof.status missing until differential_green at bound SHAs."
-	},
-	"cycle47": {
-		"boundedSlice": "tool.apply_diff",
-		"status": "harness_landed_disk",
-		"deliverables": [
-			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
-			"scripts/differential/filesystem-mcp-oracle.ts",
-			"docs/specs/filesystem-mcp-parity-slice.json",
-			"__tests__/differentialHarness.matrix.test.ts",
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-		],
-		"notes": "cycle47 rej-010: apply-diff bounded differential slice (--slice apply-diff, 5 golden cases). rust_impl only — proof.status missing until differential_green at bound SHAs."
-	},
-	"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice all",
-	"verificationRef": "verification/filesystem-mcp-differential-green.json",
-	"cycle50Slice": "apply-diff — bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-	"cycle51Slice": "list-files — bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice list-files",
-	"cycle62Slice": "replace-content — bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice replace-content; proof.status missing; authority_rust blocked per rej-010",
-	"cycle63Slice": "chmod-items — bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chmod-items; proof.status missing; authority_rust blocked per rej-010",
-	"cycle64Slice": "chown-items — bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chown-items; proof.status missing; authority_rust blocked per rej-010",
-	"cycle50": {
-		"boundedSlice": "apply-diff",
-		"status": "rust_impl_on_disk_verified",
-		"reauditRef": "rej-010",
-		"verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
-		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-		"deliverables": [
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-			"scripts/differential/filesystem-mcp-oracle.ts",
-			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
-			"__tests__/differentialHarness.matrix.test.ts"
-		],
-		"caseCounts": {
-			"applyDiff": 5
-		},
-		"notes": "cycle50 rej-010: apply-diff bounded differential harness on-disk verify. rust_impl ONLY — proof.status missing until differential_green at bound SHAs."
-	},
-	"cycle51": {
-		"boundedSlice": "list-files",
-		"status": "rust_impl_on_disk_verified",
-		"reauditRef": "rej-010",
-		"verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
-		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
-		"deliverables": [
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-			"scripts/differential/filesystem-mcp-oracle.ts",
-			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
-			"__tests__/differentialHarness.matrix.test.ts",
-			"test/fixtures/golden/list_read.golden.json"
-		],
-		"caseCounts": {
-			"listFiles": 2
-		},
-		"notes": "cycle51 rej-010: list-files bounded differential harness on-disk verify. rust_impl ONLY — proof.status missing until differential_green at bound SHAs."
-	},
-	"cycle62": {
-		"boundedSlice": "replace-content",
-		"status": "rust_impl_on_disk_verified",
-		"reauditRef": "rej-010",
-		"verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
-		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-		"deliverables": [
-			"crates/filesystem-core/src/replace_content.rs",
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-			"scripts/differential/filesystem-mcp-oracle.ts",
-			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
-			"test/fixtures/golden/replace_content.golden.json"
-		],
-		"caseCounts": {
-			"replaceContent": 2
-		},
-		"notes": "cycle62 rej-010: tool/replace_content ts_only→rust_impl bounded differential harness on-disk verify. rust_impl ONLY — proof.status missing until differential_green at bound SHAs."
-	},
-	"cycle63": {
-		"boundedSlice": "chmod-items",
-		"status": "rust_impl_on_disk_verified",
-		"reauditRef": "rej-010",
-		"verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
-		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-		"deliverables": [
-			"crates/filesystem-core/src/chmod_items.rs",
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-			"scripts/differential/filesystem-mcp-oracle.ts",
-			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
-			"test/fixtures/golden/chmod_items.golden.json",
-			"crates/filesystem-mcp-server/src/tool_routes.rs"
-		],
-		"caseCounts": {
-			"chmodItems": 2
-		},
-		"notes": "cycle63 rej-010: tool/chmod_items ts_only→rust_impl bounded differential harness on-disk verify. rust_impl ONLY — proof.status missing until differential_green at bound SHAs."
-	},
-	"cycle64": {
-		"boundedSlice": "chown-items",
-		"status": "rust_impl_on_disk_verified",
-		"reauditRef": "rej-010",
-		"verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
-		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-		"deliverables": [
-			"crates/filesystem-core/src/chown_items.rs",
-			"scripts/run-filesystem-mcp-differential.sh",
-			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-			"scripts/differential/filesystem-mcp-oracle.ts",
-			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
-			"test/fixtures/golden/chown_items.golden.json",
-			"crates/filesystem-mcp-server/src/tool_routes.rs"
-		],
-		"caseCounts": {
-			"chownItems": 2
-		},
-		"notes": "cycle64 rej-010: tool/chown_items ts_only→rust_impl bounded differential harness on-disk verify. rust_impl ONLY — proof.status missing until differential_green at bound SHAs."
-	},
-	"promotionHold": {
-		"active": true,
-		"reason": "rej-010: differential_green at bound SHAs — promotion_hold until prod_audit_pass",
-		"rejectionRef": "rej-010",
-		"since": "2026-07-10T10:53:32+00:00"
-	},
-	"differentialGreen": {
-		"status": "superseded_by_tick016_allow_list",
-		"note": "Prior 36-case multi-tool green was off dirty branch SHAs; main allow-list is list/read/write only until auditor rebinds."
-	},
-	"tick010": {
-		"boundedSlice": "list-files",
-		"status": "harness_landed_pending_main_proof",
-		"successorOf": "PR#200 (DIRTY — not merged)",
-		"notes": "Clean successor from main; list_files only; no authority_rust/ts_deleted."
-	},
-	"tick016": {
-		"boundedSlices": ["list-files", "read-content", "write-content"],
-		"status": "harness_landed_pending_main_proof",
-		"successorOf": "tick-010 list_files-only main land (#202)",
-		"notes": "Expand main differential beyond list_files. NO authority_rust/ts_deleted/prod_audit_pass."
-	},
-	"tick022": {
-		"boundedSlices": ["list-files", "read-content", "write-content", "search-files", "stat-items"],
-		"status": "harness_landed_pending_main_proof",
-		"successorOf": "tick-016 list/read/write main land (#205)",
-		"caseCounts": {
-			"list_files": 2,
-			"read_content": 4,
-			"write_content": 4,
-			"search_files": 4,
-			"stat_items": 3
-		},
-		"notes": "Expand main differential to next highest-value RustCore tools (search_files + stat_items). Fixes search_files CLI MCP envelope for cli_bridge. NO authority_rust/ts_deleted/prod_audit_pass."
-	}
+  "schemaVersion": 3,
+  "repo": "SylphxAI/filesystem-mcp",
+  "repoLedgerPath": "docs/specs/migration-ledger.json",
+  "lockedAt": "2026-07-09T22:00:00Z",
+  "programSpec": {
+    "id": "rust-first-fleet-migration",
+    "controlPlaneRepo": "SylphxAI/rust-first-fleet-control-plane",
+    "programSpecPath": "PROGRAM-SPEC.json",
+    "completionStandard": "COMPLETION-STANDARD.md",
+    "parityStandard": "PARITY-VERIFICATION-STANDARD.md"
+  },
+  "adrRefs": [
+    {
+      "path": "docs/adr/ADR-PROPOSED-fleet-filesystem-mcp-rust-north-star.md",
+      "status": "proposed",
+      "note": "North Star ADR on disk \u2014 pending ADR PR; ADR number will equal introducing PR number per Doctrine"
+    }
+  ],
+  "inventorySource": [
+    "mcp-tools",
+    "manual"
+  ],
+  "inScopeBoundary": {
+    "includeGlobs": [
+      "src/**",
+      "crates/filesystem-core/**",
+      "crates/filesystem-cli/**",
+      "crates/filesystem-mcp-server/**",
+      "bin/**",
+      "__tests__/**",
+      "scripts/differential/**"
+    ],
+    "excludeGlobs": [
+      "node_modules/**",
+      "dist/**",
+      "coverage/**"
+    ]
+  },
+  "capabilities": [
+    {
+      "id": "transport/web-mcp-http",
+      "domain": "transport",
+      "weight": 5,
+      "state": "rust_impl",
+      "rustSurface": "crates/filesystem-mcp-server/src/http_transport.rs (rmcp StreamableHttpService)",
+      "parityTest": "__tests__/transport/httpTransport.matrix.test.ts",
+      "prodProbe": "benchmark:release-gate \u2192 mcp:rust_web_http_transport"
+    },
+    {
+      "id": "transport/stdio-rust-rmcp",
+      "domain": "transport",
+      "weight": 4,
+      "state": "rust_impl",
+      "rustSurface": "crates/filesystem-mcp-server/src/main.rs (rmcp::transport::stdio())",
+      "prodProbe": "benchmark:release-gate \u2192 mcp:rust_adapter_default"
+    },
+    {
+      "id": "transport/stdio-ts-adapter",
+      "domain": "transport",
+      "weight": 4,
+      "state": "ts_only",
+      "tsSurface": "src/index.ts",
+      "notes": "Opt-in TS stdio MCP adapter (FILESYSTEM_MCP_TRANSPORT=ts); retained until ts_deleted."
+    },
+    {
+      "id": "tool/list_files",
+      "domain": "mcp-tools",
+      "weight": 4,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: main-bound multi-tool differential (list/read/write) \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-11T00:00:00+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
+        "dependencyGlobs": [
+          "src/handlers/list-files.ts",
+          "src/engine/rust-walk.ts",
+          "crates/filesystem-core/src/walk.rs",
+          "crates/filesystem-cli/src/main.rs",
+          "crates/filesystem-mcp-server/src/cli_bridge.rs",
+          "test/fixtures/golden/list_read.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ]
+      },
+      "tsSurface": "src/handlers/list-files.ts; src/engine/rust-walk.ts (opt-out via FILESYSTEM_USE_RUST_WALK=ts)",
+      "rustSurface": "crates/filesystem-core/src/walk.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice list-files",
+      "branch": "feat/expand-diff-main-tick016",
+      "notes": "tick-016: main-bound differential remains list_files + expanded siblings. rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
+    },
+    {
+      "id": "tool/search_files",
+      "domain": "mcp-tools",
+      "weight": 4,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: main-bound search_files differential harness (tick-022) \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-11T12:00:00+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "scripts/run-filesystem-mcp-differential.sh --slice search-files",
+        "dependencyGlobs": [
+          "src/handlers/search-files.ts",
+          "src/engine/rust-search.ts",
+          "crates/filesystem-core/src/search.rs",
+          "crates/filesystem-cli/src/main.rs",
+          "crates/filesystem-mcp-server/src/cli_bridge.rs",
+          "test/fixtures/golden/search_stat.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ]
+      },
+      "tsSurface": "src/handlers/search-files.ts; src/engine/rust-search.ts (opt-in via FILESYSTEM_USE_RUST_SEARCH=1)",
+      "rustSurface": "crates/filesystem-core/src/search.rs \u2192 crates/filesystem-cli (MCP CallToolResult envelope)",
+      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#search_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice search-files",
+      "branch": "feat/expand-diff-search-stat-tick022",
+      "notes": "tick-022: main-bound search_files differential (4 golden cases) + CLI MCP envelope fix (LegacyToolSuccessEnvelope). rust_impl ONLY \u2014 authority_rust NOT claimed."
+    },
+    {
+      "id": "tool/read_content",
+      "domain": "mcp-tools",
+      "weight": 4,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: main-bound read_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-11T00:00:00+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "scripts/run-filesystem-mcp-differential.sh --slice read-content",
+        "dependencyGlobs": [
+          "src/handlers/read-content.ts",
+          "src/engine/rust-content.ts",
+          "crates/filesystem-core/src/content.rs",
+          "crates/filesystem-cli/src/main.rs",
+          "crates/filesystem-mcp-server/src/cli_bridge.rs",
+          "test/fixtures/golden/list_read.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ]
+      },
+      "tsSurface": "src/handlers/read-content.ts; src/engine/rust-content.ts (opt-out via FILESYSTEM_USE_RUST_CONTENT=ts)",
+      "rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice read-content",
+      "branch": "feat/expand-diff-main-tick016",
+      "notes": "tick-016: main-bound read_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
+    },
+    {
+      "id": "tool/write_content",
+      "domain": "mcp-tools",
+      "weight": 4,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: main-bound write_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-11T00:00:00+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "scripts/run-filesystem-mcp-differential.sh --slice write-content",
+        "dependencyGlobs": [
+          "src/handlers/write-content.ts",
+          "src/engine/rust-write.ts",
+          "crates/filesystem-core/src/content.rs",
+          "crates/filesystem-cli/src/main.rs",
+          "crates/filesystem-mcp-server/src/cli_bridge.rs",
+          "test/fixtures/golden/write_content.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ]
+      },
+      "tsSurface": "src/handlers/write-content.ts; src/engine/rust-write.ts (opt-out via FILESYSTEM_USE_RUST_WRITE=ts)",
+      "rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/write_content.golden.json; __tests__/engine/writeContentGoldenParity.test.ts; cargo test -p filesystem-cli --test write_content_golden_parity",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice write-content",
+      "branch": "feat/expand-diff-main-tick016",
+      "notes": "tick-016: main-bound write_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
+    },
+    {
+      "id": "tool/stat_items",
+      "domain": "mcp-tools",
+      "weight": 4,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: main-bound stat_items differential harness (tick-022) \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-11T12:00:00+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "scripts/run-filesystem-mcp-differential.sh --slice stat-items",
+        "dependencyGlobs": [
+          "src/handlers/stat-items.ts",
+          "crates/filesystem-core/src/content.rs",
+          "crates/filesystem-cli/src/main.rs",
+          "crates/filesystem-mcp-server/src/cli_bridge.rs",
+          "test/fixtures/golden/search_stat.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ]
+      },
+      "tsSurface": "src/handlers/stat-items.ts",
+      "rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
+      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#stat_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice stat-items",
+      "branch": "feat/expand-diff-search-stat-tick022",
+      "notes": "tick-022: main-bound stat_items differential (3 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed."
+    },
+    {
+      "id": "tool/delete_items",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "tsSurface": "src/handlers/delete-items.ts",
+      "rustSurface": "crates/filesystem-core/src/content.rs#delete_items \u2192 crates/filesystem-cli",
+      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: delete_items differential harness landed tick029 \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-11T19:00:00+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "scripts/run-filesystem-mcp-differential.sh --slice delete-items",
+        "dependencyGlobs": [
+          "src/handlers/delete-items.ts",
+          "crates/filesystem-core/src/content.rs",
+          "crates/filesystem-cli/src/main.rs",
+          "crates/filesystem-mcp-server/src/tool_routes.rs",
+          "test/fixtures/golden/delete_items.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ]
+      },
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#delete_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice delete-items",
+      "branch": "feat/delete-items-differential-tick029",
+      "notes": "TICK029: delete_items native Rust core + main-bound differential harness (2 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
+    },
+    {
+      "id": "tool/create_directories",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "tsSurface": "src/handlers/create-directories.ts",
+      "rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
+      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+    },
+    {
+      "id": "tool/chmod_items",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-10T10:53:32+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
+        "dependencyGlobs": [
+          "src/handlers/chmod-items.ts",
+          "crates/filesystem-core/src/chmod_items.rs",
+          "test/fixtures/golden/chmod_items.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh"
+        ],
+        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+      },
+      "tsSurface": "src/handlers/chmod-items.ts",
+      "rustSurface": "crates/filesystem-core/src/chmod_items.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/chmod_items.golden.json; __tests__/handlers/chmod-items.test.ts",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
+      "notes": "Cycle63 rej-010: chmod_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+    },
+    {
+      "id": "tool/chown_items",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-10T10:53:32+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
+        "dependencyGlobs": [
+          "src/handlers/chown-items.ts",
+          "crates/filesystem-core/src/chown_items.rs",
+          "test/fixtures/golden/chown_items.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh"
+        ],
+        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+      },
+      "tsSurface": "src/handlers/chown-items.ts",
+      "rustSurface": "crates/filesystem-core/src/chown_items.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/chown_items.golden.json",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
+      "notes": "Cycle64 rej-010: chown_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+    },
+    {
+      "id": "tool/move_items",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "tsSurface": "src/handlers/move-items.ts",
+      "rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
+      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+    },
+    {
+      "id": "tool/copy_items",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "tsSurface": "src/handlers/copy-items.ts",
+      "rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
+      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+    },
+    {
+      "id": "tool/replace_content",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-10T10:53:32+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+        "dependencyGlobs": [
+          "src/handlers/replace-content.ts",
+          "test/fixtures/golden/replace_content.golden.json",
+          "crates/filesystem-core/src/replace_content.rs",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh"
+        ],
+        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+      },
+      "tsSurface": "src/handlers/replace-content.ts",
+      "rustSurface": "crates/filesystem-core/src/replace_content.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/replace_content.golden.json; __tests__/handlers/replace-content.success.test.ts",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+      "notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+    },
+    {
+      "id": "tool/apply_diff",
+      "domain": "mcp-tools",
+      "weight": 3,
+      "state": "rust_impl",
+      "promotionHold": {
+        "active": true,
+        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+        "rejectionRef": "rej-010",
+        "since": "2026-07-10T10:53:32+00:00"
+      },
+      "proof": {
+        "status": "missing",
+        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+        "dependencyGlobs": [
+          "src/handlers/apply-diff.ts",
+          "test/fixtures/golden/apply_diff.golden.json",
+          "scripts/differential/**",
+          "scripts/run-filesystem-mcp-differential.sh",
+          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+        ],
+        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+      },
+      "tsSurface": "src/handlers/apply-diff.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
+      "rustSurface": "crates/filesystem-core/src/apply_diff.rs \u2192 crates/filesystem-cli",
+      "parityTest": "test/fixtures/golden/apply_diff.golden.json; __tests__/engine/applyDiffGoldenParity.test.ts; cargo test -p filesystem-cli --test apply_diff_golden_parity",
+      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+      "branch": "feat/rust-web-mcp-http-transport",
+      "notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only \u2014 authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+    }
+  ],
+  "summary": {
+    "total": 16,
+    "ts_only": 1,
+    "contracted": 0,
+    "rust_impl": 15,
+    "parity_proven": 7,
+    "authority_rust": 0,
+    "ts_deleted": 0,
+    "proof_missing": 0,
+    "completion_progress": 0.0,
+    "authority_progress": 0.0,
+    "verified_authority_progress": 0,
+    "weighted_progress": 0.3445,
+    "cycle50_delta": {
+      "rust_impl_verified": 1,
+      "slice": "apply-diff",
+      "verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
+      "notes": "rej-010 rust_impl ONLY \u2014 cycle50 highest-value unimplemented slice: apply-diff bounded differential (5 golden cases)"
+    },
+    "cycle51_delta": {
+      "rust_impl_verified": 1,
+      "slice": "list-files",
+      "verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
+      "notes": "rej-010 rust_impl ONLY \u2014 cycle51 next highest-value slice: list-files bounded differential (2 golden cases)"
+    },
+    "cycle62_delta": {
+      "rust_impl_verified": 1,
+      "slice": "replace-content",
+      "verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
+      "notes": "rej-010 rust_impl ONLY \u2014 cycle62 next ts_only slice: replace-content bounded differential (2 golden cases)"
+    },
+    "cycle63_delta": {
+      "rust_impl_verified": 1,
+      "slice": "chmod-items",
+      "verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
+      "notes": "rej-010 rust_impl ONLY \u2014 cycle63 next ts_only slice: chmod-items bounded differential (2 golden cases)"
+    },
+    "cycle64_delta": {
+      "rust_impl_verified": 1,
+      "slice": "chown-items",
+      "verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
+      "notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
+    },
+    "summaryNote": "tick-016 expand main-bound differential: list_files + read_content + write_content. rej-010 promotion_hold active; authority_rust NOT claimed; NO prod_audit_pass.",
+    "tick016_delta": {
+      "rust_impl_verified": 0,
+      "slices": [
+        "list-files",
+        "read-content",
+        "write-content"
+      ],
+      "notes": "Main-bound differential allow-list expansion. Case floors: list>=2, read>=4, write>=4. Residual caps remain for search/stat/mutations/legacy tools."
+    },
+    "tick029_delta": {
+      "rust_impl_verified": 1,
+      "slice": "delete-items",
+      "verificationRef": "scripts/run-filesystem-mcp-differential.sh --slice delete-items",
+      "notes": "rej-010 rust_impl ONLY \u2014 TICK029 delete_items bounded differential (2 golden cases); no authority_rust/ts_deleted"
+    }
+  },
+  "priorClaims": {
+    "authority_rust": 4,
+    "rust_impl": 8,
+    "completion_progress": 0.0,
+    "authority_progress": 0.25,
+    "revertedAt": "2026-07-10T21:30:00Z",
+    "reason": "rej-010 promotion freeze \u2014 0 capabilities with differential_green or canary_green proof"
+  },
+  "rej010Reaudit": {
+    "appliedAt": "2026-07-11T12:00:00Z",
+    "harness": "scripts/run-filesystem-mcp-differential.sh",
+    "boundedSlices": {
+      "list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
+      "read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
+      "write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle"
+    },
+    "oracle": "scripts/differential/filesystem-mcp-oracle.ts",
+    "capabilitiesWithDifferentialHarness": 3,
+    "promotionHoldActive": true,
+    "allowList": [
+      "list_files",
+      "read_content",
+      "write_content"
+    ],
+    "notes": "tick-016 fail-closed main allow-list; other tools residual until next expansion"
+  },
+  "cycle38": {
+    "boundedSlice": "tool.list_files|tool.read_content",
+    "status": "harness_landed_disk",
+    "evidenceRef": "/tmp/grok-goal-729a939ec6e2/implementer/cycle38-mcp/cycle38-mcp.json",
+    "deliverables": [
+      "docs/specs/filesystem-mcp-parity-slice.json",
+      "__tests__/differentialHarness.matrix.test.ts",
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+    ],
+    "notes": "cycle38 rej-010: list-read bounded differential harness + matrix gate confirmed on disk. rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "cycle43": {
+    "boundedSlice": "tool.write_content",
+    "status": "harness_landed_disk",
+    "deliverables": [
+      "docs/specs/filesystem-mcp-parity-slice.json",
+      "__tests__/differentialHarness.matrix.test.ts",
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+    ],
+    "notes": "cycle43 rej-010: write-content bounded differential slice (--slice write-content). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "cycle47": {
+    "boundedSlice": "tool.apply_diff",
+    "status": "harness_landed_disk",
+    "deliverables": [
+      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
+      "scripts/differential/filesystem-mcp-oracle.ts",
+      "docs/specs/filesystem-mcp-parity-slice.json",
+      "__tests__/differentialHarness.matrix.test.ts",
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+    ],
+    "notes": "cycle47 rej-010: apply-diff bounded differential slice (--slice apply-diff, 5 golden cases). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice all",
+  "verificationRef": "verification/filesystem-mcp-differential-green.json",
+  "cycle50Slice": "apply-diff \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+  "cycle51Slice": "list-files \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice list-files",
+  "cycle62Slice": "replace-content \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice replace-content; proof.status missing; authority_rust blocked per rej-010",
+  "cycle63Slice": "chmod-items \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chmod-items; proof.status missing; authority_rust blocked per rej-010",
+  "cycle64Slice": "chown-items \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chown-items; proof.status missing; authority_rust blocked per rej-010",
+  "cycle50": {
+    "boundedSlice": "apply-diff",
+    "status": "rust_impl_on_disk_verified",
+    "reauditRef": "rej-010",
+    "verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
+    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+    "deliverables": [
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+      "scripts/differential/filesystem-mcp-oracle.ts",
+      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
+      "__tests__/differentialHarness.matrix.test.ts"
+    ],
+    "caseCounts": {
+      "applyDiff": 5
+    },
+    "notes": "cycle50 rej-010: apply-diff bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "cycle51": {
+    "boundedSlice": "list-files",
+    "status": "rust_impl_on_disk_verified",
+    "reauditRef": "rej-010",
+    "verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
+    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
+    "deliverables": [
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+      "scripts/differential/filesystem-mcp-oracle.ts",
+      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
+      "__tests__/differentialHarness.matrix.test.ts",
+      "test/fixtures/golden/list_read.golden.json"
+    ],
+    "caseCounts": {
+      "listFiles": 2
+    },
+    "notes": "cycle51 rej-010: list-files bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "cycle62": {
+    "boundedSlice": "replace-content",
+    "status": "rust_impl_on_disk_verified",
+    "reauditRef": "rej-010",
+    "verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
+    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+    "deliverables": [
+      "crates/filesystem-core/src/replace_content.rs",
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+      "scripts/differential/filesystem-mcp-oracle.ts",
+      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
+      "test/fixtures/golden/replace_content.golden.json"
+    ],
+    "caseCounts": {
+      "replaceContent": 2
+    },
+    "notes": "cycle62 rej-010: tool/replace_content ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "cycle63": {
+    "boundedSlice": "chmod-items",
+    "status": "rust_impl_on_disk_verified",
+    "reauditRef": "rej-010",
+    "verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
+    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
+    "deliverables": [
+      "crates/filesystem-core/src/chmod_items.rs",
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+      "scripts/differential/filesystem-mcp-oracle.ts",
+      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
+      "test/fixtures/golden/chmod_items.golden.json",
+      "crates/filesystem-mcp-server/src/tool_routes.rs"
+    ],
+    "caseCounts": {
+      "chmodItems": 2
+    },
+    "notes": "cycle63 rej-010: tool/chmod_items ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "cycle64": {
+    "boundedSlice": "chown-items",
+    "status": "rust_impl_on_disk_verified",
+    "reauditRef": "rej-010",
+    "verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
+    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chown-items",
+    "deliverables": [
+      "crates/filesystem-core/src/chown_items.rs",
+      "scripts/run-filesystem-mcp-differential.sh",
+      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+      "scripts/differential/filesystem-mcp-oracle.ts",
+      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
+      "test/fixtures/golden/chown_items.golden.json",
+      "crates/filesystem-mcp-server/src/tool_routes.rs"
+    ],
+    "caseCounts": {
+      "chownItems": 2
+    },
+    "notes": "cycle64 rej-010: tool/chown_items ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+  },
+  "promotionHold": {
+    "active": true,
+    "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+    "rejectionRef": "rej-010",
+    "since": "2026-07-10T10:53:32+00:00"
+  },
+  "differentialGreen": {
+    "status": "superseded_by_tick016_allow_list",
+    "note": "Prior 36-case multi-tool green was off dirty branch SHAs; main allow-list is list/read/write only until auditor rebinds."
+  },
+  "tick010": {
+    "boundedSlice": "list-files",
+    "status": "harness_landed_pending_main_proof",
+    "successorOf": "PR#200 (DIRTY \u2014 not merged)",
+    "notes": "Clean successor from main; list_files only; no authority_rust/ts_deleted."
+  },
+  "tick016": {
+    "boundedSlices": [
+      "list-files",
+      "read-content",
+      "write-content"
+    ],
+    "status": "harness_landed_pending_main_proof",
+    "successorOf": "tick-010 list_files-only main land (#202)",
+    "notes": "Expand main differential beyond list_files. NO authority_rust/ts_deleted/prod_audit_pass."
+  },
+  "tick022": {
+    "boundedSlices": [
+      "list-files",
+      "read-content",
+      "write-content",
+      "search-files",
+      "stat-items"
+    ],
+    "status": "harness_landed_pending_main_proof",
+    "successorOf": "tick-016 list/read/write main land (#205)",
+    "caseCounts": {
+      "list_files": 2,
+      "read_content": 4,
+      "write_content": 4,
+      "search_files": 4,
+      "stat_items": 3
+    },
+    "notes": "Expand main differential to next highest-value RustCore tools (search_files + stat_items). Fixes search_files CLI MCP envelope for cli_bridge. NO authority_rust/ts_deleted/prod_audit_pass."
+  }
 }

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -1,677 +1,652 @@
 {
-  "schemaVersion": 3,
-  "repo": "SylphxAI/filesystem-mcp",
-  "repoLedgerPath": "docs/specs/migration-ledger.json",
-  "lockedAt": "2026-07-09T22:00:00Z",
-  "programSpec": {
-    "id": "rust-first-fleet-migration",
-    "controlPlaneRepo": "SylphxAI/rust-first-fleet-control-plane",
-    "programSpecPath": "PROGRAM-SPEC.json",
-    "completionStandard": "COMPLETION-STANDARD.md",
-    "parityStandard": "PARITY-VERIFICATION-STANDARD.md"
-  },
-  "adrRefs": [
-    {
-      "path": "docs/adr/ADR-PROPOSED-fleet-filesystem-mcp-rust-north-star.md",
-      "status": "proposed",
-      "note": "North Star ADR on disk \u2014 pending ADR PR; ADR number will equal introducing PR number per Doctrine"
-    }
-  ],
-  "inventorySource": [
-    "mcp-tools",
-    "manual"
-  ],
-  "inScopeBoundary": {
-    "includeGlobs": [
-      "src/**",
-      "crates/filesystem-core/**",
-      "crates/filesystem-cli/**",
-      "crates/filesystem-mcp-server/**",
-      "bin/**",
-      "__tests__/**",
-      "scripts/differential/**"
-    ],
-    "excludeGlobs": [
-      "node_modules/**",
-      "dist/**",
-      "coverage/**"
-    ]
-  },
-  "capabilities": [
-    {
-      "id": "transport/web-mcp-http",
-      "domain": "transport",
-      "weight": 5,
-      "state": "rust_impl",
-      "rustSurface": "crates/filesystem-mcp-server/src/http_transport.rs (rmcp StreamableHttpService)",
-      "parityTest": "__tests__/transport/httpTransport.matrix.test.ts",
-      "prodProbe": "benchmark:release-gate \u2192 mcp:rust_web_http_transport"
-    },
-    {
-      "id": "transport/stdio-rust-rmcp",
-      "domain": "transport",
-      "weight": 4,
-      "state": "rust_impl",
-      "rustSurface": "crates/filesystem-mcp-server/src/main.rs (rmcp::transport::stdio())",
-      "prodProbe": "benchmark:release-gate \u2192 mcp:rust_adapter_default"
-    },
-    {
-      "id": "transport/stdio-ts-adapter",
-      "domain": "transport",
-      "weight": 4,
-      "state": "ts_only",
-      "tsSurface": "src/index.ts",
-      "notes": "Opt-in TS stdio MCP adapter (FILESYSTEM_MCP_TRANSPORT=ts); retained until ts_deleted."
-    },
-    {
-      "id": "tool/list_files",
-      "domain": "mcp-tools",
-      "weight": 4,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: main-bound multi-tool differential (list/read/write) \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-11T00:00:00+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
-        "dependencyGlobs": [
-          "src/handlers/list-files.ts",
-          "src/engine/rust-walk.ts",
-          "crates/filesystem-core/src/walk.rs",
-          "crates/filesystem-cli/src/main.rs",
-          "crates/filesystem-mcp-server/src/cli_bridge.rs",
-          "test/fixtures/golden/list_read.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ]
-      },
-      "tsSurface": "src/handlers/list-files.ts; src/engine/rust-walk.ts (opt-out via FILESYSTEM_USE_RUST_WALK=ts)",
-      "rustSurface": "crates/filesystem-core/src/walk.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice list-files",
-      "branch": "feat/expand-diff-main-tick016",
-      "notes": "tick-016: main-bound differential remains list_files + expanded siblings. rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
-    },
-    {
-      "id": "tool/search_files",
-      "domain": "mcp-tools",
-      "weight": 4,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: main-bound search_files differential harness (tick-022) \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-11T12:00:00+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "scripts/run-filesystem-mcp-differential.sh --slice search-files",
-        "dependencyGlobs": [
-          "src/handlers/search-files.ts",
-          "src/engine/rust-search.ts",
-          "crates/filesystem-core/src/search.rs",
-          "crates/filesystem-cli/src/main.rs",
-          "crates/filesystem-mcp-server/src/cli_bridge.rs",
-          "test/fixtures/golden/search_stat.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ]
-      },
-      "tsSurface": "src/handlers/search-files.ts; src/engine/rust-search.ts (opt-in via FILESYSTEM_USE_RUST_SEARCH=1)",
-      "rustSurface": "crates/filesystem-core/src/search.rs \u2192 crates/filesystem-cli (MCP CallToolResult envelope)",
-      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#search_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice search-files",
-      "branch": "feat/expand-diff-search-stat-tick022",
-      "notes": "tick-022: main-bound search_files differential (4 golden cases) + CLI MCP envelope fix (LegacyToolSuccessEnvelope). rust_impl ONLY \u2014 authority_rust NOT claimed."
-    },
-    {
-      "id": "tool/read_content",
-      "domain": "mcp-tools",
-      "weight": 4,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: main-bound read_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-11T00:00:00+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "scripts/run-filesystem-mcp-differential.sh --slice read-content",
-        "dependencyGlobs": [
-          "src/handlers/read-content.ts",
-          "src/engine/rust-content.ts",
-          "crates/filesystem-core/src/content.rs",
-          "crates/filesystem-cli/src/main.rs",
-          "crates/filesystem-mcp-server/src/cli_bridge.rs",
-          "test/fixtures/golden/list_read.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ]
-      },
-      "tsSurface": "src/handlers/read-content.ts; src/engine/rust-content.ts (opt-out via FILESYSTEM_USE_RUST_CONTENT=ts)",
-      "rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice read-content",
-      "branch": "feat/expand-diff-main-tick016",
-      "notes": "tick-016: main-bound read_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
-    },
-    {
-      "id": "tool/write_content",
-      "domain": "mcp-tools",
-      "weight": 4,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: main-bound write_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-11T00:00:00+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "scripts/run-filesystem-mcp-differential.sh --slice write-content",
-        "dependencyGlobs": [
-          "src/handlers/write-content.ts",
-          "src/engine/rust-write.ts",
-          "crates/filesystem-core/src/content.rs",
-          "crates/filesystem-cli/src/main.rs",
-          "crates/filesystem-mcp-server/src/cli_bridge.rs",
-          "test/fixtures/golden/write_content.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ]
-      },
-      "tsSurface": "src/handlers/write-content.ts; src/engine/rust-write.ts (opt-out via FILESYSTEM_USE_RUST_WRITE=ts)",
-      "rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/write_content.golden.json; __tests__/engine/writeContentGoldenParity.test.ts; cargo test -p filesystem-cli --test write_content_golden_parity",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice write-content",
-      "branch": "feat/expand-diff-main-tick016",
-      "notes": "tick-016: main-bound write_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
-    },
-    {
-      "id": "tool/stat_items",
-      "domain": "mcp-tools",
-      "weight": 4,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: main-bound stat_items differential harness (tick-022) \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-11T12:00:00+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "scripts/run-filesystem-mcp-differential.sh --slice stat-items",
-        "dependencyGlobs": [
-          "src/handlers/stat-items.ts",
-          "crates/filesystem-core/src/content.rs",
-          "crates/filesystem-cli/src/main.rs",
-          "crates/filesystem-mcp-server/src/cli_bridge.rs",
-          "test/fixtures/golden/search_stat.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ]
-      },
-      "tsSurface": "src/handlers/stat-items.ts",
-      "rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
-      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#stat_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice stat-items",
-      "branch": "feat/expand-diff-search-stat-tick022",
-      "notes": "tick-022: main-bound stat_items differential (3 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed."
-    },
-    {
-      "id": "tool/delete_items",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "tsSurface": "src/handlers/delete-items.ts",
-      "rustSurface": "crates/filesystem-core/src/content.rs#delete_items \u2192 crates/filesystem-cli",
-      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: delete_items differential harness landed tick029 \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-11T19:00:00+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "scripts/run-filesystem-mcp-differential.sh --slice delete-items",
-        "dependencyGlobs": [
-          "src/handlers/delete-items.ts",
-          "crates/filesystem-core/src/content.rs",
-          "crates/filesystem-cli/src/main.rs",
-          "crates/filesystem-mcp-server/src/tool_routes.rs",
-          "test/fixtures/golden/delete_items.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ]
-      },
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#delete_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice delete-items",
-      "branch": "feat/delete-items-differential-tick029",
-      "notes": "TICK029: delete_items native Rust core + main-bound differential harness (2 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
-    },
-    {
-      "id": "tool/create_directories",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "tsSurface": "src/handlers/create-directories.ts",
-      "rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
-      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-    },
-    {
-      "id": "tool/chmod_items",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-10T10:53:32+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-        "dependencyGlobs": [
-          "src/handlers/chmod-items.ts",
-          "crates/filesystem-core/src/chmod_items.rs",
-          "test/fixtures/golden/chmod_items.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh"
-        ],
-        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-      },
-      "tsSurface": "src/handlers/chmod-items.ts",
-      "rustSurface": "crates/filesystem-core/src/chmod_items.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/chmod_items.golden.json; __tests__/handlers/chmod-items.test.ts",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-      "notes": "Cycle63 rej-010: chmod_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
-    },
-    {
-      "id": "tool/chown_items",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-10T10:53:32+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-        "dependencyGlobs": [
-          "src/handlers/chown-items.ts",
-          "crates/filesystem-core/src/chown_items.rs",
-          "test/fixtures/golden/chown_items.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh"
-        ],
-        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-      },
-      "tsSurface": "src/handlers/chown-items.ts",
-      "rustSurface": "crates/filesystem-core/src/chown_items.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/chown_items.golden.json",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-      "notes": "Cycle64 rej-010: chown_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
-    },
-    {
-      "id": "tool/move_items",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "tsSurface": "src/handlers/move-items.ts",
-      "rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
-      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-    },
-    {
-      "id": "tool/copy_items",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "tsSurface": "src/handlers/copy-items.ts",
-      "rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
-      "parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
-    },
-    {
-      "id": "tool/replace_content",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-10T10:53:32+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-        "dependencyGlobs": [
-          "src/handlers/replace-content.ts",
-          "test/fixtures/golden/replace_content.golden.json",
-          "crates/filesystem-core/src/replace_content.rs",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh"
-        ],
-        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-      },
-      "tsSurface": "src/handlers/replace-content.ts",
-      "rustSurface": "crates/filesystem-core/src/replace_content.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/replace_content.golden.json; __tests__/handlers/replace-content.success.test.ts",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-      "notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
-    },
-    {
-      "id": "tool/apply_diff",
-      "domain": "mcp-tools",
-      "weight": 3,
-      "state": "rust_impl",
-      "promotionHold": {
-        "active": true,
-        "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
-        "rejectionRef": "rej-010",
-        "since": "2026-07-10T10:53:32+00:00"
-      },
-      "proof": {
-        "status": "missing",
-        "harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-        "dependencyGlobs": [
-          "src/handlers/apply-diff.ts",
-          "test/fixtures/golden/apply_diff.golden.json",
-          "scripts/differential/**",
-          "scripts/run-filesystem-mcp-differential.sh",
-          "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-        ],
-        "note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
-      },
-      "tsSurface": "src/handlers/apply-diff.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
-      "rustSurface": "crates/filesystem-core/src/apply_diff.rs \u2192 crates/filesystem-cli",
-      "parityTest": "test/fixtures/golden/apply_diff.golden.json; __tests__/engine/applyDiffGoldenParity.test.ts; cargo test -p filesystem-cli --test apply_diff_golden_parity",
-      "differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-      "branch": "feat/rust-web-mcp-http-transport",
-      "notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only \u2014 authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
-    }
-  ],
-  "summary": {
-    "total": 16,
-    "ts_only": 1,
-    "contracted": 0,
-    "rust_impl": 15,
-    "parity_proven": 7,
-    "authority_rust": 0,
-    "ts_deleted": 0,
-    "proof_missing": 0,
-    "completion_progress": 0.0,
-    "authority_progress": 0.0,
-    "verified_authority_progress": 0,
-    "weighted_progress": 0.3445,
-    "cycle50_delta": {
-      "rust_impl_verified": 1,
-      "slice": "apply-diff",
-      "verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
-      "notes": "rej-010 rust_impl ONLY \u2014 cycle50 highest-value unimplemented slice: apply-diff bounded differential (5 golden cases)"
-    },
-    "cycle51_delta": {
-      "rust_impl_verified": 1,
-      "slice": "list-files",
-      "verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
-      "notes": "rej-010 rust_impl ONLY \u2014 cycle51 next highest-value slice: list-files bounded differential (2 golden cases)"
-    },
-    "cycle62_delta": {
-      "rust_impl_verified": 1,
-      "slice": "replace-content",
-      "verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
-      "notes": "rej-010 rust_impl ONLY \u2014 cycle62 next ts_only slice: replace-content bounded differential (2 golden cases)"
-    },
-    "cycle63_delta": {
-      "rust_impl_verified": 1,
-      "slice": "chmod-items",
-      "verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
-      "notes": "rej-010 rust_impl ONLY \u2014 cycle63 next ts_only slice: chmod-items bounded differential (2 golden cases)"
-    },
-    "cycle64_delta": {
-      "rust_impl_verified": 1,
-      "slice": "chown-items",
-      "verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
-      "notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
-    },
-    "summaryNote": "tick-016 expand main-bound differential: list_files + read_content + write_content. rej-010 promotion_hold active; authority_rust NOT claimed; NO prod_audit_pass.",
-    "tick016_delta": {
-      "rust_impl_verified": 0,
-      "slices": [
-        "list-files",
-        "read-content",
-        "write-content"
-      ],
-      "notes": "Main-bound differential allow-list expansion. Case floors: list>=2, read>=4, write>=4. Residual caps remain for search/stat/mutations/legacy tools."
-    },
-    "tick029_delta": {
-      "rust_impl_verified": 1,
-      "slice": "delete-items",
-      "verificationRef": "scripts/run-filesystem-mcp-differential.sh --slice delete-items",
-      "notes": "rej-010 rust_impl ONLY \u2014 TICK029 delete_items bounded differential (2 golden cases); no authority_rust/ts_deleted"
-    }
-  },
-  "priorClaims": {
-    "authority_rust": 4,
-    "rust_impl": 8,
-    "completion_progress": 0.0,
-    "authority_progress": 0.25,
-    "revertedAt": "2026-07-10T21:30:00Z",
-    "reason": "rej-010 promotion freeze \u2014 0 capabilities with differential_green or canary_green proof"
-  },
-  "rej010Reaudit": {
-    "appliedAt": "2026-07-11T12:00:00Z",
-    "harness": "scripts/run-filesystem-mcp-differential.sh",
-    "boundedSlices": {
-      "list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
-      "read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
-      "write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle"
-    },
-    "oracle": "scripts/differential/filesystem-mcp-oracle.ts",
-    "capabilitiesWithDifferentialHarness": 3,
-    "promotionHoldActive": true,
-    "allowList": [
-      "list_files",
-      "read_content",
-      "write_content"
-    ],
-    "notes": "tick-016 fail-closed main allow-list; other tools residual until next expansion"
-  },
-  "cycle38": {
-    "boundedSlice": "tool.list_files|tool.read_content",
-    "status": "harness_landed_disk",
-    "evidenceRef": "/tmp/grok-goal-729a939ec6e2/implementer/cycle38-mcp/cycle38-mcp.json",
-    "deliverables": [
-      "docs/specs/filesystem-mcp-parity-slice.json",
-      "__tests__/differentialHarness.matrix.test.ts",
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-    ],
-    "notes": "cycle38 rej-010: list-read bounded differential harness + matrix gate confirmed on disk. rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "cycle43": {
-    "boundedSlice": "tool.write_content",
-    "status": "harness_landed_disk",
-    "deliverables": [
-      "docs/specs/filesystem-mcp-parity-slice.json",
-      "__tests__/differentialHarness.matrix.test.ts",
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-    ],
-    "notes": "cycle43 rej-010: write-content bounded differential slice (--slice write-content). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "cycle47": {
-    "boundedSlice": "tool.apply_diff",
-    "status": "harness_landed_disk",
-    "deliverables": [
-      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-      "scripts/differential/filesystem-mcp-oracle.ts",
-      "docs/specs/filesystem-mcp-parity-slice.json",
-      "__tests__/differentialHarness.matrix.test.ts",
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
-    ],
-    "notes": "cycle47 rej-010: apply-diff bounded differential slice (--slice apply-diff, 5 golden cases). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice all",
-  "verificationRef": "verification/filesystem-mcp-differential-green.json",
-  "cycle50Slice": "apply-diff \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-  "cycle51Slice": "list-files \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice list-files",
-  "cycle62Slice": "replace-content \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice replace-content; proof.status missing; authority_rust blocked per rej-010",
-  "cycle63Slice": "chmod-items \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chmod-items; proof.status missing; authority_rust blocked per rej-010",
-  "cycle64Slice": "chown-items \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chown-items; proof.status missing; authority_rust blocked per rej-010",
-  "cycle50": {
-    "boundedSlice": "apply-diff",
-    "status": "rust_impl_on_disk_verified",
-    "reauditRef": "rej-010",
-    "verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
-    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-    "deliverables": [
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-      "scripts/differential/filesystem-mcp-oracle.ts",
-      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-      "__tests__/differentialHarness.matrix.test.ts"
-    ],
-    "caseCounts": {
-      "applyDiff": 5
-    },
-    "notes": "cycle50 rej-010: apply-diff bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "cycle51": {
-    "boundedSlice": "list-files",
-    "status": "rust_impl_on_disk_verified",
-    "reauditRef": "rej-010",
-    "verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
-    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
-    "deliverables": [
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-      "scripts/differential/filesystem-mcp-oracle.ts",
-      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-      "__tests__/differentialHarness.matrix.test.ts",
-      "test/fixtures/golden/list_read.golden.json"
-    ],
-    "caseCounts": {
-      "listFiles": 2
-    },
-    "notes": "cycle51 rej-010: list-files bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "cycle62": {
-    "boundedSlice": "replace-content",
-    "status": "rust_impl_on_disk_verified",
-    "reauditRef": "rej-010",
-    "verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
-    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-    "deliverables": [
-      "crates/filesystem-core/src/replace_content.rs",
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-      "scripts/differential/filesystem-mcp-oracle.ts",
-      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-      "test/fixtures/golden/replace_content.golden.json"
-    ],
-    "caseCounts": {
-      "replaceContent": 2
-    },
-    "notes": "cycle62 rej-010: tool/replace_content ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "cycle63": {
-    "boundedSlice": "chmod-items",
-    "status": "rust_impl_on_disk_verified",
-    "reauditRef": "rej-010",
-    "verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
-    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
-    "deliverables": [
-      "crates/filesystem-core/src/chmod_items.rs",
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-      "scripts/differential/filesystem-mcp-oracle.ts",
-      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-      "test/fixtures/golden/chmod_items.golden.json",
-      "crates/filesystem-mcp-server/src/tool_routes.rs"
-    ],
-    "caseCounts": {
-      "chmodItems": 2
-    },
-    "notes": "cycle63 rej-010: tool/chmod_items ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "cycle64": {
-    "boundedSlice": "chown-items",
-    "status": "rust_impl_on_disk_verified",
-    "reauditRef": "rej-010",
-    "verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
-    "harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chown-items",
-    "deliverables": [
-      "crates/filesystem-core/src/chown_items.rs",
-      "scripts/run-filesystem-mcp-differential.sh",
-      "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
-      "scripts/differential/filesystem-mcp-oracle.ts",
-      "scripts/differential/fixtures/filesystem-mcp-corpus.json",
-      "test/fixtures/golden/chown_items.golden.json",
-      "crates/filesystem-mcp-server/src/tool_routes.rs"
-    ],
-    "caseCounts": {
-      "chownItems": 2
-    },
-    "notes": "cycle64 rej-010: tool/chown_items ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
-  },
-  "promotionHold": {
-    "active": true,
-    "reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
-    "rejectionRef": "rej-010",
-    "since": "2026-07-10T10:53:32+00:00"
-  },
-  "differentialGreen": {
-    "status": "superseded_by_tick016_allow_list",
-    "note": "Prior 36-case multi-tool green was off dirty branch SHAs; main allow-list is list/read/write only until auditor rebinds."
-  },
-  "tick010": {
-    "boundedSlice": "list-files",
-    "status": "harness_landed_pending_main_proof",
-    "successorOf": "PR#200 (DIRTY \u2014 not merged)",
-    "notes": "Clean successor from main; list_files only; no authority_rust/ts_deleted."
-  },
-  "tick016": {
-    "boundedSlices": [
-      "list-files",
-      "read-content",
-      "write-content"
-    ],
-    "status": "harness_landed_pending_main_proof",
-    "successorOf": "tick-010 list_files-only main land (#202)",
-    "notes": "Expand main differential beyond list_files. NO authority_rust/ts_deleted/prod_audit_pass."
-  },
-  "tick022": {
-    "boundedSlices": [
-      "list-files",
-      "read-content",
-      "write-content",
-      "search-files",
-      "stat-items"
-    ],
-    "status": "harness_landed_pending_main_proof",
-    "successorOf": "tick-016 list/read/write main land (#205)",
-    "caseCounts": {
-      "list_files": 2,
-      "read_content": 4,
-      "write_content": 4,
-      "search_files": 4,
-      "stat_items": 3
-    },
-    "notes": "Expand main differential to next highest-value RustCore tools (search_files + stat_items). Fixes search_files CLI MCP envelope for cli_bridge. NO authority_rust/ts_deleted/prod_audit_pass."
-  }
+	"schemaVersion": 3,
+	"repo": "SylphxAI/filesystem-mcp",
+	"repoLedgerPath": "docs/specs/migration-ledger.json",
+	"lockedAt": "2026-07-09T22:00:00Z",
+	"programSpec": {
+		"id": "rust-first-fleet-migration",
+		"controlPlaneRepo": "SylphxAI/rust-first-fleet-control-plane",
+		"programSpecPath": "PROGRAM-SPEC.json",
+		"completionStandard": "COMPLETION-STANDARD.md",
+		"parityStandard": "PARITY-VERIFICATION-STANDARD.md"
+	},
+	"adrRefs": [
+		{
+			"path": "docs/adr/ADR-PROPOSED-fleet-filesystem-mcp-rust-north-star.md",
+			"status": "proposed",
+			"note": "North Star ADR on disk \u2014 pending ADR PR; ADR number will equal introducing PR number per Doctrine"
+		}
+	],
+	"inventorySource": ["mcp-tools", "manual"],
+	"inScopeBoundary": {
+		"includeGlobs": [
+			"src/**",
+			"crates/filesystem-core/**",
+			"crates/filesystem-cli/**",
+			"crates/filesystem-mcp-server/**",
+			"bin/**",
+			"__tests__/**",
+			"scripts/differential/**"
+		],
+		"excludeGlobs": ["node_modules/**", "dist/**", "coverage/**"]
+	},
+	"capabilities": [
+		{
+			"id": "transport/web-mcp-http",
+			"domain": "transport",
+			"weight": 5,
+			"state": "rust_impl",
+			"rustSurface": "crates/filesystem-mcp-server/src/http_transport.rs (rmcp StreamableHttpService)",
+			"parityTest": "__tests__/transport/httpTransport.matrix.test.ts",
+			"prodProbe": "benchmark:release-gate \u2192 mcp:rust_web_http_transport"
+		},
+		{
+			"id": "transport/stdio-rust-rmcp",
+			"domain": "transport",
+			"weight": 4,
+			"state": "rust_impl",
+			"rustSurface": "crates/filesystem-mcp-server/src/main.rs (rmcp::transport::stdio())",
+			"prodProbe": "benchmark:release-gate \u2192 mcp:rust_adapter_default"
+		},
+		{
+			"id": "transport/stdio-ts-adapter",
+			"domain": "transport",
+			"weight": 4,
+			"state": "ts_only",
+			"tsSurface": "src/index.ts",
+			"notes": "Opt-in TS stdio MCP adapter (FILESYSTEM_MCP_TRANSPORT=ts); retained until ts_deleted."
+		},
+		{
+			"id": "tool/list_files",
+			"domain": "mcp-tools",
+			"weight": 4,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: main-bound multi-tool differential (list/read/write) \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-11T00:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
+				"dependencyGlobs": [
+					"src/handlers/list-files.ts",
+					"src/engine/rust-walk.ts",
+					"crates/filesystem-core/src/walk.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
+					"test/fixtures/golden/list_read.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				]
+			},
+			"tsSurface": "src/handlers/list-files.ts; src/engine/rust-walk.ts (opt-out via FILESYSTEM_USE_RUST_WALK=ts)",
+			"rustSurface": "crates/filesystem-core/src/walk.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice list-files",
+			"branch": "feat/expand-diff-main-tick016",
+			"notes": "tick-016: main-bound differential remains list_files + expanded siblings. rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
+		},
+		{
+			"id": "tool/search_files",
+			"domain": "mcp-tools",
+			"weight": 4,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: main-bound search_files differential harness (tick-022) \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-11T12:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice search-files",
+				"dependencyGlobs": [
+					"src/handlers/search-files.ts",
+					"src/engine/rust-search.ts",
+					"crates/filesystem-core/src/search.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
+					"test/fixtures/golden/search_stat.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				]
+			},
+			"tsSurface": "src/handlers/search-files.ts; src/engine/rust-search.ts (opt-in via FILESYSTEM_USE_RUST_SEARCH=1)",
+			"rustSurface": "crates/filesystem-core/src/search.rs \u2192 crates/filesystem-cli (MCP CallToolResult envelope)",
+			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#search_files_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice search-files",
+			"branch": "feat/expand-diff-search-stat-tick022",
+			"notes": "tick-022: main-bound search_files differential (4 golden cases) + CLI MCP envelope fix (LegacyToolSuccessEnvelope). rust_impl ONLY \u2014 authority_rust NOT claimed."
+		},
+		{
+			"id": "tool/read_content",
+			"domain": "mcp-tools",
+			"weight": 4,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: main-bound read_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-11T00:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice read-content",
+				"dependencyGlobs": [
+					"src/handlers/read-content.ts",
+					"src/engine/rust-content.ts",
+					"crates/filesystem-core/src/content.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
+					"test/fixtures/golden/list_read.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				]
+			},
+			"tsSurface": "src/handlers/read-content.ts; src/engine/rust-content.ts (opt-out via FILESYSTEM_USE_RUST_CONTENT=ts)",
+			"rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/list_read.golden.json; __tests__/engine/listReadGoldenParity.test.ts; cargo test -p filesystem-cli --test list_read_golden_parity",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice read-content",
+			"branch": "feat/expand-diff-main-tick016",
+			"notes": "tick-016: main-bound read_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
+		},
+		{
+			"id": "tool/write_content",
+			"domain": "mcp-tools",
+			"weight": 4,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: main-bound write_content differential harness (tick-016) \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-11T00:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice write-content",
+				"dependencyGlobs": [
+					"src/handlers/write-content.ts",
+					"src/engine/rust-write.ts",
+					"crates/filesystem-core/src/content.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
+					"test/fixtures/golden/write_content.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				]
+			},
+			"tsSurface": "src/handlers/write-content.ts; src/engine/rust-write.ts (opt-out via FILESYSTEM_USE_RUST_WRITE=ts)",
+			"rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/write_content.golden.json; __tests__/engine/writeContentGoldenParity.test.ts; cargo test -p filesystem-cli --test write_content_golden_parity",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice write-content",
+			"branch": "feat/expand-diff-main-tick016",
+			"notes": "tick-016: main-bound write_content differential (4 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed. Stale pre-main differential_green cleared."
+		},
+		{
+			"id": "tool/stat_items",
+			"domain": "mcp-tools",
+			"weight": 4,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: main-bound stat_items differential harness (tick-022) \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-11T12:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice stat-items",
+				"dependencyGlobs": [
+					"src/handlers/stat-items.ts",
+					"crates/filesystem-core/src/content.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/cli_bridge.rs",
+					"test/fixtures/golden/search_stat.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				]
+			},
+			"tsSurface": "src/handlers/stat-items.ts",
+			"rustSurface": "crates/filesystem-core/src/content.rs \u2192 crates/filesystem-cli",
+			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts; test/fixtures/golden/search_stat.golden.json",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#stat_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice stat-items",
+			"branch": "feat/expand-diff-search-stat-tick022",
+			"notes": "tick-022: main-bound stat_items differential (3 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed."
+		},
+		{
+			"id": "tool/delete_items",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"tsSurface": "src/handlers/delete-items.ts",
+			"rustSurface": "crates/filesystem-core/src/content.rs#delete_items \u2192 crates/filesystem-cli",
+			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: delete_items differential harness landed tick029 \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-11T19:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "scripts/run-filesystem-mcp-differential.sh --slice delete-items",
+				"dependencyGlobs": [
+					"src/handlers/delete-items.ts",
+					"crates/filesystem-core/src/content.rs",
+					"crates/filesystem-cli/src/main.rs",
+					"crates/filesystem-mcp-server/src/tool_routes.rs",
+					"test/fixtures/golden/delete_items.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				]
+			},
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#delete_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice delete-items",
+			"branch": "feat/delete-items-differential-tick029",
+			"notes": "TICK029: delete_items native Rust core + main-bound differential harness (2 golden cases). rust_impl ONLY \u2014 authority_rust NOT claimed (rej-010)."
+		},
+		{
+			"id": "tool/create_directories",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"tsSurface": "src/handlers/create-directories.ts",
+			"rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
+			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+		},
+		{
+			"id": "tool/chmod_items",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-10T10:53:32+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
+				"dependencyGlobs": [
+					"src/handlers/chmod-items.ts",
+					"crates/filesystem-core/src/chmod_items.rs",
+					"test/fixtures/golden/chmod_items.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh"
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+			},
+			"tsSurface": "src/handlers/chmod-items.ts",
+			"rustSurface": "crates/filesystem-core/src/chmod_items.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/chmod_items.golden.json; __tests__/handlers/chmod-items.test.ts",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chmod_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
+			"notes": "Cycle63 rej-010: chmod_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+		},
+		{
+			"id": "tool/chown_items",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-10T10:53:32+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
+				"dependencyGlobs": [
+					"src/handlers/chown-items.ts",
+					"crates/filesystem-core/src/chown_items.rs",
+					"test/fixtures/golden/chown_items.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh"
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+			},
+			"tsSurface": "src/handlers/chown-items.ts",
+			"rustSurface": "crates/filesystem-core/src/chown_items.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/chown_items.golden.json",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#chown_items_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice chown-items",
+			"notes": "Cycle64 rej-010: chown_items rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+		},
+		{
+			"id": "tool/move_items",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"tsSurface": "src/handlers/move-items.ts",
+			"rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
+			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+		},
+		{
+			"id": "tool/copy_items",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"tsSurface": "src/handlers/copy-items.ts",
+			"rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
+			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+		},
+		{
+			"id": "tool/replace_content",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-10T10:53:32+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+				"dependencyGlobs": [
+					"src/handlers/replace-content.ts",
+					"test/fixtures/golden/replace_content.golden.json",
+					"crates/filesystem-core/src/replace_content.rs",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh"
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+			},
+			"tsSurface": "src/handlers/replace-content.ts",
+			"rustSurface": "crates/filesystem-core/src/replace_content.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/replace_content.golden.json; __tests__/handlers/replace-content.success.test.ts",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+			"notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+		},
+		{
+			"id": "tool/apply_diff",
+			"domain": "mcp-tools",
+			"weight": 3,
+			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-10T10:53:32+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+				"dependencyGlobs": [
+					"src/handlers/apply-diff.ts",
+					"test/fixtures/golden/apply_diff.golden.json",
+					"scripts/differential/**",
+					"scripts/run-filesystem-mcp-differential.sh",
+					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+				],
+				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+			},
+			"tsSurface": "src/handlers/apply-diff.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
+			"rustSurface": "crates/filesystem-core/src/apply_diff.rs \u2192 crates/filesystem-cli",
+			"parityTest": "test/fixtures/golden/apply_diff.golden.json; __tests__/engine/applyDiffGoldenParity.test.ts; cargo test -p filesystem-cli --test apply_diff_golden_parity",
+			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+			"branch": "feat/rust-web-mcp-http-transport",
+			"notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only \u2014 authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+		}
+	],
+	"summary": {
+		"total": 16,
+		"ts_only": 1,
+		"contracted": 0,
+		"rust_impl": 15,
+		"parity_proven": 7,
+		"authority_rust": 0,
+		"ts_deleted": 0,
+		"proof_missing": 0,
+		"completion_progress": 0.0,
+		"authority_progress": 0.0,
+		"verified_authority_progress": 0,
+		"weighted_progress": 0.3445,
+		"cycle50_delta": {
+			"rust_impl_verified": 1,
+			"slice": "apply-diff",
+			"verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
+			"notes": "rej-010 rust_impl ONLY \u2014 cycle50 highest-value unimplemented slice: apply-diff bounded differential (5 golden cases)"
+		},
+		"cycle51_delta": {
+			"rust_impl_verified": 1,
+			"slice": "list-files",
+			"verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
+			"notes": "rej-010 rust_impl ONLY \u2014 cycle51 next highest-value slice: list-files bounded differential (2 golden cases)"
+		},
+		"cycle62_delta": {
+			"rust_impl_verified": 1,
+			"slice": "replace-content",
+			"verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
+			"notes": "rej-010 rust_impl ONLY \u2014 cycle62 next ts_only slice: replace-content bounded differential (2 golden cases)"
+		},
+		"cycle63_delta": {
+			"rust_impl_verified": 1,
+			"slice": "chmod-items",
+			"verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
+			"notes": "rej-010 rust_impl ONLY \u2014 cycle63 next ts_only slice: chmod-items bounded differential (2 golden cases)"
+		},
+		"cycle64_delta": {
+			"rust_impl_verified": 1,
+			"slice": "chown-items",
+			"verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
+			"notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
+		},
+		"summaryNote": "tick-016 expand main-bound differential: list_files + read_content + write_content. rej-010 promotion_hold active; authority_rust NOT claimed; NO prod_audit_pass.",
+		"tick016_delta": {
+			"rust_impl_verified": 0,
+			"slices": ["list-files", "read-content", "write-content"],
+			"notes": "Main-bound differential allow-list expansion. Case floors: list>=2, read>=4, write>=4. Residual caps remain for search/stat/mutations/legacy tools."
+		},
+		"tick029_delta": {
+			"rust_impl_verified": 1,
+			"slice": "delete-items",
+			"verificationRef": "scripts/run-filesystem-mcp-differential.sh --slice delete-items",
+			"notes": "rej-010 rust_impl ONLY \u2014 TICK029 delete_items bounded differential (2 golden cases); no authority_rust/ts_deleted"
+		}
+	},
+	"priorClaims": {
+		"authority_rust": 4,
+		"rust_impl": 8,
+		"completion_progress": 0.0,
+		"authority_progress": 0.25,
+		"revertedAt": "2026-07-10T21:30:00Z",
+		"reason": "rej-010 promotion freeze \u2014 0 capabilities with differential_green or canary_green proof"
+	},
+	"rej010Reaudit": {
+		"appliedAt": "2026-07-11T12:00:00Z",
+		"harness": "scripts/run-filesystem-mcp-differential.sh",
+		"boundedSlices": {
+			"list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
+			"read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
+			"write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle"
+		},
+		"oracle": "scripts/differential/filesystem-mcp-oracle.ts",
+		"capabilitiesWithDifferentialHarness": 3,
+		"promotionHoldActive": true,
+		"allowList": ["list_files", "read_content", "write_content"],
+		"notes": "tick-016 fail-closed main allow-list; other tools residual until next expansion"
+	},
+	"cycle38": {
+		"boundedSlice": "tool.list_files|tool.read_content",
+		"status": "harness_landed_disk",
+		"evidenceRef": "/tmp/grok-goal-729a939ec6e2/implementer/cycle38-mcp/cycle38-mcp.json",
+		"deliverables": [
+			"docs/specs/filesystem-mcp-parity-slice.json",
+			"__tests__/differentialHarness.matrix.test.ts",
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+		],
+		"notes": "cycle38 rej-010: list-read bounded differential harness + matrix gate confirmed on disk. rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"cycle43": {
+		"boundedSlice": "tool.write_content",
+		"status": "harness_landed_disk",
+		"deliverables": [
+			"docs/specs/filesystem-mcp-parity-slice.json",
+			"__tests__/differentialHarness.matrix.test.ts",
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+		],
+		"notes": "cycle43 rej-010: write-content bounded differential slice (--slice write-content). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"cycle47": {
+		"boundedSlice": "tool.apply_diff",
+		"status": "harness_landed_disk",
+		"deliverables": [
+			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
+			"scripts/differential/filesystem-mcp-oracle.ts",
+			"docs/specs/filesystem-mcp-parity-slice.json",
+			"__tests__/differentialHarness.matrix.test.ts",
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
+		],
+		"notes": "cycle47 rej-010: apply-diff bounded differential slice (--slice apply-diff, 5 golden cases). rust_impl only \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice all",
+	"verificationRef": "verification/filesystem-mcp-differential-green.json",
+	"cycle50Slice": "apply-diff \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+	"cycle51Slice": "list-files \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice list-files",
+	"cycle62Slice": "replace-content \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice replace-content; proof.status missing; authority_rust blocked per rej-010",
+	"cycle63Slice": "chmod-items \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chmod-items; proof.status missing; authority_rust blocked per rej-010",
+	"cycle64Slice": "chown-items \u2014 bounded --slice entrypoint; bash scripts/run-filesystem-mcp-differential.sh --slice chown-items; proof.status missing; authority_rust blocked per rej-010",
+	"cycle50": {
+		"boundedSlice": "apply-diff",
+		"status": "rust_impl_on_disk_verified",
+		"reauditRef": "rej-010",
+		"verificationRef": "verification/filesystem-mcp-cycle50-apply-diff-rust-impl.json",
+		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
+		"deliverables": [
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+			"scripts/differential/filesystem-mcp-oracle.ts",
+			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
+			"__tests__/differentialHarness.matrix.test.ts"
+		],
+		"caseCounts": {
+			"applyDiff": 5
+		},
+		"notes": "cycle50 rej-010: apply-diff bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"cycle51": {
+		"boundedSlice": "list-files",
+		"status": "rust_impl_on_disk_verified",
+		"reauditRef": "rej-010",
+		"verificationRef": "verification/filesystem-mcp-cycle51-list-files-rust-impl.json",
+		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice list-files",
+		"deliverables": [
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+			"scripts/differential/filesystem-mcp-oracle.ts",
+			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
+			"__tests__/differentialHarness.matrix.test.ts",
+			"test/fixtures/golden/list_read.golden.json"
+		],
+		"caseCounts": {
+			"listFiles": 2
+		},
+		"notes": "cycle51 rej-010: list-files bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"cycle62": {
+		"boundedSlice": "replace-content",
+		"status": "rust_impl_on_disk_verified",
+		"reauditRef": "rej-010",
+		"verificationRef": "verification/filesystem-mcp-cycle62-replace-content-rust-impl.json",
+		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+		"deliverables": [
+			"crates/filesystem-core/src/replace_content.rs",
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+			"scripts/differential/filesystem-mcp-oracle.ts",
+			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
+			"test/fixtures/golden/replace_content.golden.json"
+		],
+		"caseCounts": {
+			"replaceContent": 2
+		},
+		"notes": "cycle62 rej-010: tool/replace_content ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"cycle63": {
+		"boundedSlice": "chmod-items",
+		"status": "rust_impl_on_disk_verified",
+		"reauditRef": "rej-010",
+		"verificationRef": "verification/filesystem-mcp-cycle63-chmod-items-rust-impl.json",
+		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chmod-items",
+		"deliverables": [
+			"crates/filesystem-core/src/chmod_items.rs",
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+			"scripts/differential/filesystem-mcp-oracle.ts",
+			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
+			"test/fixtures/golden/chmod_items.golden.json",
+			"crates/filesystem-mcp-server/src/tool_routes.rs"
+		],
+		"caseCounts": {
+			"chmodItems": 2
+		},
+		"notes": "cycle63 rej-010: tool/chmod_items ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"cycle64": {
+		"boundedSlice": "chown-items",
+		"status": "rust_impl_on_disk_verified",
+		"reauditRef": "rej-010",
+		"verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
+		"harnessPath": "scripts/run-filesystem-mcp-differential.sh --slice chown-items",
+		"deliverables": [
+			"crates/filesystem-core/src/chown_items.rs",
+			"scripts/run-filesystem-mcp-differential.sh",
+			"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs",
+			"scripts/differential/filesystem-mcp-oracle.ts",
+			"scripts/differential/fixtures/filesystem-mcp-corpus.json",
+			"test/fixtures/golden/chown_items.golden.json",
+			"crates/filesystem-mcp-server/src/tool_routes.rs"
+		],
+		"caseCounts": {
+			"chownItems": 2
+		},
+		"notes": "cycle64 rej-010: tool/chown_items ts_only\u2192rust_impl bounded differential harness on-disk verify. rust_impl ONLY \u2014 proof.status missing until differential_green at bound SHAs."
+	},
+	"promotionHold": {
+		"active": true,
+		"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+		"rejectionRef": "rej-010",
+		"since": "2026-07-10T10:53:32+00:00"
+	},
+	"differentialGreen": {
+		"status": "superseded_by_tick016_allow_list",
+		"note": "Prior 36-case multi-tool green was off dirty branch SHAs; main allow-list is list/read/write only until auditor rebinds."
+	},
+	"tick010": {
+		"boundedSlice": "list-files",
+		"status": "harness_landed_pending_main_proof",
+		"successorOf": "PR#200 (DIRTY \u2014 not merged)",
+		"notes": "Clean successor from main; list_files only; no authority_rust/ts_deleted."
+	},
+	"tick016": {
+		"boundedSlices": ["list-files", "read-content", "write-content"],
+		"status": "harness_landed_pending_main_proof",
+		"successorOf": "tick-010 list_files-only main land (#202)",
+		"notes": "Expand main differential beyond list_files. NO authority_rust/ts_deleted/prod_audit_pass."
+	},
+	"tick022": {
+		"boundedSlices": ["list-files", "read-content", "write-content", "search-files", "stat-items"],
+		"status": "harness_landed_pending_main_proof",
+		"successorOf": "tick-016 list/read/write main land (#205)",
+		"caseCounts": {
+			"list_files": 2,
+			"read_content": 4,
+			"write_content": 4,
+			"search_files": 4,
+			"stat_items": 3
+		},
+		"notes": "Expand main differential to next highest-value RustCore tools (search_files + stat_items). Fixes search_files CLI MCP envelope for cli_bridge. NO authority_rust/ts_deleted/prod_audit_pass."
+	}
 }

--- a/scripts/differential/filesystem-mcp-oracle.ts
+++ b/scripts/differential/filesystem-mcp-oracle.ts
@@ -2,7 +2,7 @@
 /**
  * TS contract oracle for filesystem-mcp differential parity (rej-010 / tick-022).
  * Frozen baseline: pure TypeScript list_files + read_content + write_content +
- * search_files + stat_items handlers on golden corpus.
+ * search_files + stat_items + delete_items handlers on golden corpus.
  * Fail-closed allow-list — no silent extra tools.
  */
 import { createHash } from 'node:crypto'
@@ -15,6 +15,7 @@ import { readContentToolDefinition } from '../../src/handlers/read-content.ts'
 import { searchFilesToolDefinition } from '../../src/handlers/search-files.ts'
 import { statItemsToolDefinition } from '../../src/handlers/stat-items.ts'
 import { writeContentToolDefinition } from '../../src/handlers/write-content.ts'
+import { deleteItemsToolDefinition } from '../../src/handlers/delete-items.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // realpath avoids /tmp vs /private/tmp drift on macOS which breaks PROJECT_ROOT confinement.
@@ -32,8 +33,9 @@ const ALLOWED_TOOLS = new Set([
 	'write_content',
 	'search_files',
 	'stat_items',
+	'delete_items',
 ] as const)
-type AllowedTool = 'list_files' | 'read_content' | 'write_content' | 'search_files' | 'stat_items'
+type AllowedTool = 'list_files' | 'read_content' | 'write_content' | 'search_files' | 'stat_items' | 'delete_items'
 
 interface ToolRouteCase {
 	id: string
@@ -58,6 +60,7 @@ interface Corpus {
 	listReadGolden: string
 	writeContentGolden: string
 	searchStatGolden: string
+	deleteItemsGolden: string
 	toolRouteCases: ToolRouteCase[]
 	serverContract: {
 		name: string
@@ -79,6 +82,7 @@ const TOOL_SLICE: Record<AllowedTool, string> = {
 	write_content: 'write-content',
 	search_files: 'search-files',
 	stat_items: 'stat-items',
+	delete_items: 'delete-items',
 }
 
 const sortPaths = (paths: string[]) => [...paths].sort()
@@ -252,7 +256,7 @@ function scopeToolInput(
 				: join(relativeRoot, String(input.path)).replace(/\\/g, '/')
 		return { ...input, path: pathValue }
 	}
-	if (tool === 'read_content' || tool === 'stat_items') {
+	if (tool === 'read_content' || tool === 'stat_items' || tool === 'delete_items') {
 		return {
 			...input,
 			paths: (input.paths as string[]).map((entry) =>
@@ -291,10 +295,31 @@ async function invokeToolHandler(
 					? writeContentToolDefinition.handler
 					: tool === 'search_files'
 						? searchFilesToolDefinition.handler
-						: statItemsToolDefinition.handler
+						: tool === 'delete_items'
+							? deleteItemsToolDefinition.handler
+							: statItemsToolDefinition.handler
 	const response = await handler(scopedInput)
 	return JSON.parse(response.content[0].text)
 }
+
+
+const normalizeDeletePayload = (
+	results: Array<{ path?: string; success?: boolean; note?: string; error?: string }>,
+	prefix: string,
+) =>
+	results.map((entry) => {
+		const normalized: Record<string, unknown> = {
+			path: stripCorpusPrefix(entry.path ?? '', prefix),
+			success: entry.success,
+		}
+		if (entry.note) {
+			normalized.note = entry.note
+		}
+		if (entry.error) {
+			normalized.error = entry.error
+		}
+		return normalized
+	})
 
 function normalizeToolPayload(tool: AllowedTool, payload: unknown, prefix: string): unknown {
 	if (tool === 'list_files') {
@@ -313,6 +338,17 @@ function normalizeToolPayload(tool: AllowedTool, payload: unknown, prefix: strin
 				success?: boolean
 				operation?: string
 				code?: string
+				error?: string
+			}>,
+			prefix,
+		)
+	}
+	if (tool === 'delete_items') {
+		return normalizeDeletePayload(
+			payload as Array<{
+				path?: string
+				success?: boolean
+				note?: string
 				error?: string
 			}>,
 			prefix,
@@ -374,6 +410,9 @@ async function main(): Promise<void> {
 	) as GoldenManifest
 	const searchStatManifest = JSON.parse(
 		readFileSync(join(REPO_ROOT, corpus.searchStatGolden), 'utf8'),
+	) as GoldenManifest
+	const deleteManifest = JSON.parse(
+		readFileSync(join(REPO_ROOT, corpus.deleteItemsGolden), 'utf8'),
 	) as GoldenManifest
 
 	const cases: DifferentialCase[] = []
@@ -477,6 +516,31 @@ async function main(): Promise<void> {
 				status: 'ok',
 				engine: 'filesystem-core',
 				payload: normalizeToolPayload(testCase.tool, payload, listReadPrefix),
+			},
+		})
+	}
+
+	// delete_items mutates isolated corpus copies (same pattern as write_content).
+	for (const testCase of deleteManifest.cases) {
+		assertAllowedTool(testCase.tool, `deleteItemsGolden/${testCase.id}`)
+		const caseRoot = join(SCRATCH_ROOT, 'cases', testCase.id)
+		copyCorpus(caseRoot, corpusSource)
+		const casePrefix = corpusPrefixFor(caseRoot)
+		const payload = await invokeToolHandler(testCase.tool, caseRoot, testCase.input)
+		cases.push({
+			id: `tool-${testCase.id}`,
+			slice: TOOL_SLICE[testCase.tool],
+			domain: 'tool',
+			input: {
+				tool: testCase.tool,
+				root: caseRoot,
+				args: testCase.input,
+				isolate: true,
+			},
+			output: {
+				status: 'ok',
+				engine: 'filesystem-core',
+				payload: normalizeToolPayload(testCase.tool, payload, casePrefix),
 			},
 		})
 	}

--- a/scripts/differential/filesystem-mcp-oracle.ts
+++ b/scripts/differential/filesystem-mcp-oracle.ts
@@ -10,12 +10,12 @@ import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync } fro
 import { readFile } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { deleteItemsToolDefinition } from '../../src/handlers/delete-items.ts'
 import { listFilesToolDefinition } from '../../src/handlers/list-files.ts'
 import { readContentToolDefinition } from '../../src/handlers/read-content.ts'
 import { searchFilesToolDefinition } from '../../src/handlers/search-files.ts'
 import { statItemsToolDefinition } from '../../src/handlers/stat-items.ts'
 import { writeContentToolDefinition } from '../../src/handlers/write-content.ts'
-import { deleteItemsToolDefinition } from '../../src/handlers/delete-items.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // realpath avoids /tmp vs /private/tmp drift on macOS which breaks PROJECT_ROOT confinement.
@@ -35,7 +35,13 @@ const ALLOWED_TOOLS = new Set([
 	'stat_items',
 	'delete_items',
 ] as const)
-type AllowedTool = 'list_files' | 'read_content' | 'write_content' | 'search_files' | 'stat_items' | 'delete_items'
+type AllowedTool =
+	| 'list_files'
+	| 'read_content'
+	| 'write_content'
+	| 'search_files'
+	| 'stat_items'
+	| 'delete_items'
 
 interface ToolRouteCase {
 	id: string
@@ -301,7 +307,6 @@ async function invokeToolHandler(
 	const response = await handler(scopedInput)
 	return JSON.parse(response.content[0].text)
 }
-
 
 const normalizeDeletePayload = (
 	results: Array<{ path?: string; success?: boolean; note?: string; error?: string }>,

--- a/scripts/differential/fixtures/filesystem-mcp-corpus.json
+++ b/scripts/differential/fixtures/filesystem-mcp-corpus.json
@@ -1,51 +1,51 @@
 {
-  "corpusVersion": 1,
-  "corpusRoot": "test/fixtures/golden/corpus",
-  "listReadGolden": "test/fixtures/golden/list_read.golden.json",
-  "writeContentGolden": "test/fixtures/golden/write_content.golden.json",
-  "searchStatGolden": "test/fixtures/golden/search_stat.golden.json",
-  "toolRouteCases": [
-    {
-      "id": "route-list-files",
-      "tool": "list_files",
-      "expect": "RustCore"
-    },
-    {
-      "id": "route-read-content",
-      "tool": "read_content",
-      "expect": "RustCore"
-    },
-    {
-      "id": "route-write-content",
-      "tool": "write_content",
-      "expect": "RustCore"
-    },
-    {
-      "id": "route-search-files",
-      "tool": "search_files",
-      "expect": "RustCore"
-    },
-    {
-      "id": "route-stat-items",
-      "tool": "stat_items",
-      "expect": "RustCore"
-    },
-    {
-      "id": "route-delete-items",
-      "tool": "delete_items",
-      "expect": "RustCore"
-    }
-  ],
-  "serverContract": {
-    "name": "filesystem-mcp",
-    "tools": [
-      "list_files",
-      "read_content",
-      "write_content",
-      "search_files",
-      "stat_items",
-      "delete_items"
-    ]
-  },
-  "deleteItemsGolden": "test/fixtures/golden/delete_items.golden.json"
+	"corpusVersion": 1,
+	"corpusRoot": "test/fixtures/golden/corpus",
+	"listReadGolden": "test/fixtures/golden/list_read.golden.json",
+	"writeContentGolden": "test/fixtures/golden/write_content.golden.json",
+	"searchStatGolden": "test/fixtures/golden/search_stat.golden.json",
+	"toolRouteCases": [
+		{
+			"id": "route-list-files",
+			"tool": "list_files",
+			"expect": "RustCore"
+		},
+		{
+			"id": "route-read-content",
+			"tool": "read_content",
+			"expect": "RustCore"
+		},
+		{
+			"id": "route-write-content",
+			"tool": "write_content",
+			"expect": "RustCore"
+		},
+		{
+			"id": "route-search-files",
+			"tool": "search_files",
+			"expect": "RustCore"
+		},
+		{
+			"id": "route-stat-items",
+			"tool": "stat_items",
+			"expect": "RustCore"
+		},
+		{
+			"id": "route-delete-items",
+			"tool": "delete_items",
+			"expect": "RustCore"
+		}
+	],
+	"serverContract": {
+		"name": "filesystem-mcp",
+		"tools": [
+			"list_files",
+			"read_content",
+			"write_content",
+			"search_files",
+			"stat_items",
+			"delete_items"
+		]
+	},
+	"deleteItemsGolden": "test/fixtures/golden/delete_items.golden.json"
 }

--- a/scripts/differential/fixtures/filesystem-mcp-corpus.json
+++ b/scripts/differential/fixtures/filesystem-mcp-corpus.json
@@ -1,38 +1,51 @@
 {
-	"corpusVersion": 1,
-	"corpusRoot": "test/fixtures/golden/corpus",
-	"listReadGolden": "test/fixtures/golden/list_read.golden.json",
-	"writeContentGolden": "test/fixtures/golden/write_content.golden.json",
-	"searchStatGolden": "test/fixtures/golden/search_stat.golden.json",
-	"toolRouteCases": [
-		{
-			"id": "route-list-files",
-			"tool": "list_files",
-			"expect": "RustCore"
-		},
-		{
-			"id": "route-read-content",
-			"tool": "read_content",
-			"expect": "RustCore"
-		},
-		{
-			"id": "route-write-content",
-			"tool": "write_content",
-			"expect": "RustCore"
-		},
-		{
-			"id": "route-search-files",
-			"tool": "search_files",
-			"expect": "RustCore"
-		},
-		{
-			"id": "route-stat-items",
-			"tool": "stat_items",
-			"expect": "RustCore"
-		}
-	],
-	"serverContract": {
-		"name": "filesystem-mcp",
-		"tools": ["list_files", "read_content", "write_content", "search_files", "stat_items"]
-	}
+  "corpusVersion": 1,
+  "corpusRoot": "test/fixtures/golden/corpus",
+  "listReadGolden": "test/fixtures/golden/list_read.golden.json",
+  "writeContentGolden": "test/fixtures/golden/write_content.golden.json",
+  "searchStatGolden": "test/fixtures/golden/search_stat.golden.json",
+  "toolRouteCases": [
+    {
+      "id": "route-list-files",
+      "tool": "list_files",
+      "expect": "RustCore"
+    },
+    {
+      "id": "route-read-content",
+      "tool": "read_content",
+      "expect": "RustCore"
+    },
+    {
+      "id": "route-write-content",
+      "tool": "write_content",
+      "expect": "RustCore"
+    },
+    {
+      "id": "route-search-files",
+      "tool": "search_files",
+      "expect": "RustCore"
+    },
+    {
+      "id": "route-stat-items",
+      "tool": "stat_items",
+      "expect": "RustCore"
+    },
+    {
+      "id": "route-delete-items",
+      "tool": "delete_items",
+      "expect": "RustCore"
+    }
+  ],
+  "serverContract": {
+    "name": "filesystem-mcp",
+    "tools": [
+      "list_files",
+      "read_content",
+      "write_content",
+      "search_files",
+      "stat_items",
+      "delete_items"
+    ]
+  },
+  "deleteItemsGolden": "test/fixtures/golden/delete_items.golden.json"
 }

--- a/scripts/run-filesystem-mcp-differential.sh
+++ b/scripts/run-filesystem-mcp-differential.sh
@@ -20,7 +20,7 @@ SLICE_FILTER="all"
 : >"$LOG"
 
 # Fail-closed allow-list of main-bound differential slices.
-ALLOWED_SLICES="all|list-files|read-content|write-content|search-files|stat-items"
+ALLOWED_SLICES="all|list-files|read-content|write-content|search-files|stat-items|delete-items"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,7 +36,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SLICE_FILTER" in
-  all|list-files|read-content|write-content|search-files|stat-items) ;;
+  all|list-files|read-content|write-content|search-files|stat-items|delete-items) ;;
   *)
     echo "::error::invalid --slice value: $SLICE_FILTER (supported: $ALLOWED_SLICES)" | tee -a "$LOG"
     exit 1
@@ -88,17 +88,21 @@ case "$SLICE_FILTER" in
   stat-items)
     run_rust_slice_test "stat-items" stat_items_differential_matches_ts_oracle
     ;;
+  delete-items)
+    run_rust_slice_test "delete-items" delete_items_differential_matches_ts_oracle
+    ;;
   all)
     run_rust_slice_test "list-files" list_files_differential_matches_ts_oracle
     run_rust_slice_test "read-content" read_content_differential_matches_ts_oracle
     run_rust_slice_test "write-content" write_content_differential_matches_ts_oracle
     run_rust_slice_test "search-files" search_files_differential_matches_ts_oracle
     run_rust_slice_test "stat-items" stat_items_differential_matches_ts_oracle
+    run_rust_slice_test "delete-items" delete_items_differential_matches_ts_oracle
     ;;
 esac
 
 CANDIDATE_SHA="${CANDIDATE_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
-BASELINE_TS_SHA="$(git -C "$REPO_ROOT" log -1 --format=%H -- scripts/differential src/handlers/list-files.ts src/handlers/read-content.ts src/handlers/write-content.ts src/handlers/search-files.ts src/handlers/stat-items.ts test/fixtures/golden 2>/dev/null || echo unknown)"
+BASELINE_TS_SHA="$(git -C "$REPO_ROOT" log -1 --format=%H -- scripts/differential src/handlers/list-files.ts src/handlers/read-content.ts src/handlers/write-content.ts src/handlers/search-files.ts src/handlers/stat-items.ts src/handlers/delete-items.ts test/fixtures/golden 2>/dev/null || echo unknown)"
 RUST_SHA="$CANDIDATE_SHA"
 BEHAVIOR_SPEC_HASH="$(sha256sum "$REPO_ROOT/scripts/differential/fixtures/filesystem-mcp-corpus.json" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$REPO_ROOT/scripts/differential/fixtures/filesystem-mcp-corpus.json" | awk '{print $1}')"
 FIXTURE_CORPUS_HASH="$(jq -r '.fixtureCorpusHash' "$ORACLE_JSON")"
@@ -108,6 +112,7 @@ READ_CASE_COUNT="$(jq '[.cases[] | select(.slice=="read-content")] | length' "$O
 WRITE_CASE_COUNT="$(jq '[.cases[] | select(.slice=="write-content")] | length' "$ORACLE_JSON")"
 SEARCH_CASE_COUNT="$(jq '[.cases[] | select(.slice=="search-files")] | length' "$ORACLE_JSON")"
 STAT_CASE_COUNT="$(jq '[.cases[] | select(.slice=="stat-items")] | length' "$ORACLE_JSON")"
+DELETE_CASE_COUNT="$(jq '[.cases[] | select(.slice=="delete-items")] | length' "$ORACLE_JSON")"
 
 jq -n \
   --arg verifiedAt "$(date -Iseconds)" \
@@ -122,10 +127,11 @@ jq -n \
   --argjson writeCaseCount "$WRITE_CASE_COUNT" \
   --argjson searchCaseCount "$SEARCH_CASE_COUNT" \
   --argjson statCaseCount "$STAT_CASE_COUNT" \
+  --argjson deleteCaseCount "$DELETE_CASE_COUNT" \
   --arg sliceFilter "$SLICE_FILTER" \
   '{
     schemaVersion: 2,
-    slice: ("filesystem-mcp.tools.list_files|read_content|write_content|search_files|stat_items|" + $sliceFilter),
+    slice: ("filesystem-mcp.tools.list_files|read_content|write_content|search_files|stat_items|delete_items|" + $sliceFilter),
     status: "differential_green",
     verifiedAt: $verifiedAt,
     lastComparedMainSha: $candidateSha,
@@ -140,18 +146,20 @@ jq -n \
     writeContentCaseCount: $writeCaseCount,
     searchFilesCaseCount: $searchCaseCount,
     statItemsCaseCount: $statCaseCount,
+    deleteItemsCaseCount: $deleteCaseCount,
     harness: "scripts/run-filesystem-mcp-differential.sh",
-    differentialTest: "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle;read_content_differential_matches_ts_oracle;write_content_differential_matches_ts_oracle;search_files_differential_matches_ts_oracle;stat_items_differential_matches_ts_oracle",
+    differentialTest: "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle;read_content_differential_matches_ts_oracle;write_content_differential_matches_ts_oracle;search_files_differential_matches_ts_oracle;stat_items_differential_matches_ts_oracle;delete_items_differential_matches_ts_oracle",
     boundedSlices: {
       "list-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#list_files_differential_matches_ts_oracle",
       "read-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#read_content_differential_matches_ts_oracle",
       "write-content": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#write_content_differential_matches_ts_oracle",
       "search-files": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#search_files_differential_matches_ts_oracle",
-      "stat-items": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#stat_items_differential_matches_ts_oracle"
+      "stat-items": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#stat_items_differential_matches_ts_oracle",
+      "delete-items": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#delete_items_differential_matches_ts_oracle"
     },
     oracle: "scripts/differential/filesystem-mcp-oracle.ts",
     promotionPolicy: "NO_PROMOTIONS — differential_green recorded per rej-010; promotion_hold until prod_audit_pass; authority_rust NOT claimed"
   }' >"$ARTIFACT"
 
-echo "filesystem-mcp-differential: OK (slice=$SLICE_FILTER cases=$CASE_COUNT list_files=$LIST_CASE_COUNT read_content=$READ_CASE_COUNT write_content=$WRITE_CASE_COUNT search_files=$SEARCH_CASE_COUNT stat_items=$STAT_CASE_COUNT corpus=$FIXTURE_CORPUS_HASH)" | tee -a "$LOG"
+echo "filesystem-mcp-differential: OK (slice=$SLICE_FILTER cases=$CASE_COUNT list_files=$LIST_CASE_COUNT read_content=$READ_CASE_COUNT write_content=$WRITE_CASE_COUNT search_files=$SEARCH_CASE_COUNT stat_items=$STAT_CASE_COUNT delete_items=$DELETE_CASE_COUNT corpus=$FIXTURE_CORPUS_HASH)" | tee -a "$LOG"
 echo "verification artifact: $ARTIFACT" | tee -a "$LOG"

--- a/test/fixtures/golden/delete_items.golden.json
+++ b/test/fixtures/golden/delete_items.golden.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "source": "TICK029 delete_items differential expansion",
+  "corpusRoot": "test/fixtures/golden/corpus",
+  "cases": [
+    {
+      "id": "delete-file-success",
+      "tool": "delete_items",
+      "input": {
+        "paths": ["alpha.txt"]
+      },
+      "expects": {
+        "results": [
+          { "path": "alpha.txt", "success": true }
+        ]
+      }
+    },
+    {
+      "id": "delete-missing-idempotent",
+      "tool": "delete_items",
+      "input": {
+        "paths": ["does-not-exist.txt"]
+      },
+      "expects": {
+        "results": [
+          {
+            "path": "does-not-exist.txt",
+            "success": true,
+            "note": "Path not found, nothing to delete"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/golden/delete_items.golden.json
+++ b/test/fixtures/golden/delete_items.golden.json
@@ -1,35 +1,33 @@
 {
-  "schemaVersion": 1,
-  "source": "TICK029 delete_items differential expansion",
-  "corpusRoot": "test/fixtures/golden/corpus",
-  "cases": [
-    {
-      "id": "delete-file-success",
-      "tool": "delete_items",
-      "input": {
-        "paths": ["alpha.txt"]
-      },
-      "expects": {
-        "results": [
-          { "path": "alpha.txt", "success": true }
-        ]
-      }
-    },
-    {
-      "id": "delete-missing-idempotent",
-      "tool": "delete_items",
-      "input": {
-        "paths": ["does-not-exist.txt"]
-      },
-      "expects": {
-        "results": [
-          {
-            "path": "does-not-exist.txt",
-            "success": true,
-            "note": "Path not found, nothing to delete"
-          }
-        ]
-      }
-    }
-  ]
+	"schemaVersion": 1,
+	"source": "TICK029 delete_items differential expansion",
+	"corpusRoot": "test/fixtures/golden/corpus",
+	"cases": [
+		{
+			"id": "delete-file-success",
+			"tool": "delete_items",
+			"input": {
+				"paths": ["alpha.txt"]
+			},
+			"expects": {
+				"results": [{ "path": "alpha.txt", "success": true }]
+			}
+		},
+		{
+			"id": "delete-missing-idempotent",
+			"tool": "delete_items",
+			"input": {
+				"paths": ["does-not-exist.txt"]
+			},
+			"expects": {
+				"results": [
+					{
+						"path": "does-not-exist.txt",
+						"success": true,
+						"note": "Path not found, nothing to delete"
+					}
+				]
+			}
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- Native Rust `delete_items` in `filesystem-core` (ENOENT idempotent parity with TS)
- CLI + tool route promoted to `RustCore`
- Main-bound differential harness: `scripts/run-filesystem-mcp-differential.sh --slice delete-items` (2 golden cases)
- Ledger: `tool/delete_items` remains `rust_impl` with promotion_hold (rej-010)

## Verification
```
bash scripts/run-filesystem-mcp-differential.sh --slice delete-items
# delete_items_differential_matches_ts_oracle ... ok
```

## Freezes
- No `authority_rust` / `ts_deleted` / complete claims (rej-010/011/013)