### PR TITLE
test(core): FLEET pure residual chmod/chown/walk/diff/search (no route flip)

### DIFF
--- a/crates/filesystem-core/fixtures/apply_diff_golden.json
+++ b/crates/filesystem-core/fixtures/apply_diff_golden.json
@@ -1,71 +1,71 @@
 {
-  "schema": "filesystem-core/apply_diff_golden/v1",
-  "source": "src/utils/apply-diff-utils.ts + src/utils/string-utils.ts",
-  "note": "BW2 offline pure residual deepen — proof_missing until tip differential allow-list expansion",
-  "cases": [
-    {
-      "id": "replace-version-line",
-      "original": "export const version = '1.0.0';\n",
-      "diffs": [
-        {
-          "search": "export const version = '1.0.0';",
-          "replace": "export const version = '1.0.1';",
-          "start_line": 1,
-          "end_line": 1,
-          "operation": "replace"
-        }
-      ],
-      "expectSuccess": true,
-      "expectNewContent": "export const version = '1.0.1';\n"
-    },
-    {
-      "id": "content-mismatch",
-      "original": "aaa\nbbb\nccc\n",
-      "diffs": [
-        {
-          "search": "xxx",
-          "replace": "yyy",
-          "start_line": 2,
-          "end_line": 2
-        }
-      ],
-      "expectSuccess": false,
-      "errorContains": "Content mismatch"
-    },
-    {
-      "id": "insert-middle",
-      "original": "a\nc\n",
-      "diffs": [
-        {
-          "search": "",
-          "replace": "b",
-          "start_line": 2,
-          "end_line": 1,
-          "operation": "insert"
-        }
-      ],
-      "expectSuccess": true,
-      "expectNewContent": "a\nb\nc\n"
-    },
-    {
-      "id": "multi-bottom-up",
-      "original": "one\ntwo\nthree\n",
-      "diffs": [
-        {
-          "search": "one",
-          "replace": "1",
-          "start_line": 1,
-          "end_line": 1
-        },
-        {
-          "search": "three",
-          "replace": "3",
-          "start_line": 3,
-          "end_line": 3
-        }
-      ],
-      "expectSuccess": true,
-      "expectNewContent": "1\ntwo\n3\n"
-    }
-  ]
+	"schema": "filesystem-core/apply_diff_golden/v1",
+	"source": "src/utils/apply-diff-utils.ts + src/utils/string-utils.ts",
+	"note": "BW2 offline pure residual deepen — proof_missing until tip differential allow-list expansion",
+	"cases": [
+		{
+			"id": "replace-version-line",
+			"original": "export const version = '1.0.0';\n",
+			"diffs": [
+				{
+					"search": "export const version = '1.0.0';",
+					"replace": "export const version = '1.0.1';",
+					"start_line": 1,
+					"end_line": 1,
+					"operation": "replace"
+				}
+			],
+			"expectSuccess": true,
+			"expectNewContent": "export const version = '1.0.1';\n"
+		},
+		{
+			"id": "content-mismatch",
+			"original": "aaa\nbbb\nccc\n",
+			"diffs": [
+				{
+					"search": "xxx",
+					"replace": "yyy",
+					"start_line": 2,
+					"end_line": 2
+				}
+			],
+			"expectSuccess": false,
+			"errorContains": "Content mismatch"
+		},
+		{
+			"id": "insert-middle",
+			"original": "a\nc\n",
+			"diffs": [
+				{
+					"search": "",
+					"replace": "b",
+					"start_line": 2,
+					"end_line": 1,
+					"operation": "insert"
+				}
+			],
+			"expectSuccess": true,
+			"expectNewContent": "a\nb\nc\n"
+		},
+		{
+			"id": "multi-bottom-up",
+			"original": "one\ntwo\nthree\n",
+			"diffs": [
+				{
+					"search": "one",
+					"replace": "1",
+					"start_line": 1,
+					"end_line": 1
+				},
+				{
+					"search": "three",
+					"replace": "3",
+					"start_line": 3,
+					"end_line": 3
+				}
+			],
+			"expectSuccess": true,
+			"expectNewContent": "1\ntwo\n3\n"
+		}
+	]
 }

--- a/crates/filesystem-core/fixtures/apply_diff_golden.json
+++ b/crates/filesystem-core/fixtures/apply_diff_golden.json
@@ -1,0 +1,71 @@
+{
+  "schema": "filesystem-core/apply_diff_golden/v1",
+  "source": "src/utils/apply-diff-utils.ts + src/utils/string-utils.ts",
+  "note": "BW2 offline pure residual deepen — proof_missing until tip differential allow-list expansion",
+  "cases": [
+    {
+      "id": "replace-version-line",
+      "original": "export const version = '1.0.0';\n",
+      "diffs": [
+        {
+          "search": "export const version = '1.0.0';",
+          "replace": "export const version = '1.0.1';",
+          "start_line": 1,
+          "end_line": 1,
+          "operation": "replace"
+        }
+      ],
+      "expectSuccess": true,
+      "expectNewContent": "export const version = '1.0.1';\n"
+    },
+    {
+      "id": "content-mismatch",
+      "original": "aaa\nbbb\nccc\n",
+      "diffs": [
+        {
+          "search": "xxx",
+          "replace": "yyy",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "expectSuccess": false,
+      "errorContains": "Content mismatch"
+    },
+    {
+      "id": "insert-middle",
+      "original": "a\nc\n",
+      "diffs": [
+        {
+          "search": "",
+          "replace": "b",
+          "start_line": 2,
+          "end_line": 1,
+          "operation": "insert"
+        }
+      ],
+      "expectSuccess": true,
+      "expectNewContent": "a\nb\nc\n"
+    },
+    {
+      "id": "multi-bottom-up",
+      "original": "one\ntwo\nthree\n",
+      "diffs": [
+        {
+          "search": "one",
+          "replace": "1",
+          "start_line": 1,
+          "end_line": 1
+        },
+        {
+          "search": "three",
+          "replace": "3",
+          "start_line": 3,
+          "end_line": 3
+        }
+      ],
+      "expectSuccess": true,
+      "expectNewContent": "1\ntwo\n3\n"
+    }
+  ]
+}

--- a/crates/filesystem-core/fixtures/mutations_golden.json
+++ b/crates/filesystem-core/fixtures/mutations_golden.json
@@ -1,49 +1,95 @@
 {
-  "schema": "filesystem-core/mutations_golden/v1",
-  "source": "src/handlers/create-directories.ts; src/handlers/move-items.ts; src/handlers/copy-items.ts",
-  "note": "BW2 offline pure residual deepen — proof_missing until CLI wire + tip differential allow-list expansion; route LegacyOptIn",
-  "cases": [
-    {
-      "id": "create-nested-dirs",
-      "op": "create_directories",
-      "paths": ["a/b/c"],
-      "expectSuccess": [true],
-      "expectExistsDirs": ["a/b/c"]
-    },
-    {
-      "id": "create-rejects-root",
-      "op": "create_directories",
-      "paths": [""],
-      "expectSuccess": [false],
-      "errorContains": ["project root"]
-    },
-    {
-      "id": "move-file",
-      "op": "move_items",
-      "seedFiles": { "src/a.txt": "hello" },
-      "operations": [{ "source": "src/a.txt", "destination": "dst/b.txt" }],
-      "expectSuccess": [true],
-      "expectExistsFiles": { "dst/b.txt": "hello" },
-      "expectMissing": ["src/a.txt"]
-    },
-    {
-      "id": "copy-file-preserves-source",
-      "op": "copy_items",
-      "seedFiles": { "solo.txt": "solo" },
-      "operations": [{ "source": "solo.txt", "destination": "copy-solo.txt" }],
-      "expectSuccess": [true],
-      "expectExistsFiles": { "solo.txt": "solo", "copy-solo.txt": "solo" }
-    },
-    {
-      "id": "copy-directory-tree",
-      "op": "copy_items",
-      "seedFiles": { "tree/nested/leaf.txt": "leaf" },
-      "operations": [{ "source": "tree", "destination": "tree-copy" }],
-      "expectSuccess": [true],
-      "expectExistsFiles": {
-        "tree/nested/leaf.txt": "leaf",
-        "tree-copy/nested/leaf.txt": "leaf"
-      }
-    }
-  ]
+	"schema": "filesystem-core/mutations_golden/v1",
+	"source": "src/handlers/create-directories.ts; src/handlers/move-items.ts; src/handlers/copy-items.ts",
+	"note": "BW2 offline pure residual deepen — proof_missing until CLI wire + tip differential allow-list expansion; route LegacyOptIn",
+	"cases": [
+		{
+			"id": "create-nested-dirs",
+			"op": "create_directories",
+			"paths": [
+				"a/b/c"
+			],
+			"expectSuccess": [
+				true
+			],
+			"expectExistsDirs": [
+				"a/b/c"
+			]
+		},
+		{
+			"id": "create-rejects-root",
+			"op": "create_directories",
+			"paths": [
+				""
+			],
+			"expectSuccess": [
+				false
+			],
+			"errorContains": [
+				"project root"
+			]
+		},
+		{
+			"id": "move-file",
+			"op": "move_items",
+			"seedFiles": {
+				"src/a.txt": "hello"
+			},
+			"operations": [
+				{
+					"source": "src/a.txt",
+					"destination": "dst/b.txt"
+				}
+			],
+			"expectSuccess": [
+				true
+			],
+			"expectExistsFiles": {
+				"dst/b.txt": "hello"
+			},
+			"expectMissing": [
+				"src/a.txt"
+			]
+		},
+		{
+			"id": "copy-file-preserves-source",
+			"op": "copy_items",
+			"seedFiles": {
+				"solo.txt": "solo"
+			},
+			"operations": [
+				{
+					"source": "solo.txt",
+					"destination": "copy-solo.txt"
+				}
+			],
+			"expectSuccess": [
+				true
+			],
+			"expectExistsFiles": {
+				"solo.txt": "solo",
+				"copy-solo.txt": "solo"
+			}
+		},
+		{
+			"id": "copy-directory-tree",
+			"op": "copy_items",
+			"seedFiles": {
+				"tree/nested/leaf.txt": "leaf"
+			},
+			"operations": [
+				{
+					"source": "tree",
+					"destination": "tree-copy"
+				}
+			],
+			"expectSuccess": [
+				true
+			],
+			"expectExistsFiles": {
+				"tree/nested/leaf.txt": "leaf",
+				"tree-copy/nested/leaf.txt": "leaf"
+			}
+		}
+	]
 }

--- a/crates/filesystem-core/fixtures/mutations_golden.json
+++ b/crates/filesystem-core/fixtures/mutations_golden.json
@@ -1,0 +1,49 @@
+{
+  "schema": "filesystem-core/mutations_golden/v1",
+  "source": "src/handlers/create-directories.ts; src/handlers/move-items.ts; src/handlers/copy-items.ts",
+  "note": "BW2 offline pure residual deepen — proof_missing until CLI wire + tip differential allow-list expansion; route LegacyOptIn",
+  "cases": [
+    {
+      "id": "create-nested-dirs",
+      "op": "create_directories",
+      "paths": ["a/b/c"],
+      "expectSuccess": [true],
+      "expectExistsDirs": ["a/b/c"]
+    },
+    {
+      "id": "create-rejects-root",
+      "op": "create_directories",
+      "paths": [""],
+      "expectSuccess": [false],
+      "errorContains": ["project root"]
+    },
+    {
+      "id": "move-file",
+      "op": "move_items",
+      "seedFiles": { "src/a.txt": "hello" },
+      "operations": [{ "source": "src/a.txt", "destination": "dst/b.txt" }],
+      "expectSuccess": [true],
+      "expectExistsFiles": { "dst/b.txt": "hello" },
+      "expectMissing": ["src/a.txt"]
+    },
+    {
+      "id": "copy-file-preserves-source",
+      "op": "copy_items",
+      "seedFiles": { "solo.txt": "solo" },
+      "operations": [{ "source": "solo.txt", "destination": "copy-solo.txt" }],
+      "expectSuccess": [true],
+      "expectExistsFiles": { "solo.txt": "solo", "copy-solo.txt": "solo" }
+    },
+    {
+      "id": "copy-directory-tree",
+      "op": "copy_items",
+      "seedFiles": { "tree/nested/leaf.txt": "leaf" },
+      "operations": [{ "source": "tree", "destination": "tree-copy" }],
+      "expectSuccess": [true],
+      "expectExistsFiles": {
+        "tree/nested/leaf.txt": "leaf",
+        "tree-copy/nested/leaf.txt": "leaf"
+      }
+    }
+  ]
+}

--- a/crates/filesystem-core/fixtures/replace_content_golden.json
+++ b/crates/filesystem-core/fixtures/replace_content_golden.json
@@ -1,0 +1,73 @@
+{
+  "schema": "filesystem-core/replace_content_golden/v1",
+  "source": "src/handlers/replace-content.ts (applyReplaceOperation + createSearchRegex)",
+  "note": "BW2 offline pure residual deepen — proof_missing until CLI wire + tip differential allow-list expansion; route LegacyOptIn",
+  "cases": [
+    {
+      "id": "simple-literal-multi",
+      "original": "Hello world, world!",
+      "operations": [
+        { "search": "world", "replace": "planet", "use_regex": false, "ignore_case": false }
+      ],
+      "expectModified": true,
+      "expectReplacements": 2,
+      "expectNewContent": "Hello planet, planet!"
+    },
+    {
+      "id": "sequential-ops",
+      "original": "Hello world, world!",
+      "operations": [
+        { "search": "world", "replace": "galaxy", "use_regex": false, "ignore_case": false },
+        { "search": "galaxy", "replace": "universe", "use_regex": false, "ignore_case": false }
+      ],
+      "expectModified": true,
+      "expectReplacements": 4,
+      "expectNewContent": "Hello universe, universe!"
+    },
+    {
+      "id": "regex-capture-multiline-anchor",
+      "original": "Error: world not found.\nWarning: world might be deprecated.",
+      "operations": [
+        {
+          "search": "^(Error|Warning):",
+          "replace": "Log[$1]:",
+          "use_regex": true,
+          "ignore_case": false
+        }
+      ],
+      "expectModified": true,
+      "expectReplacements": 2,
+      "expectNewContent": "Log[Error]: world not found.\nLog[Warning]: world might be deprecated."
+    },
+    {
+      "id": "case-insensitive",
+      "original": "Hello world, world!",
+      "operations": [
+        { "search": "hello", "replace": "Greetings", "use_regex": false, "ignore_case": true }
+      ],
+      "expectModified": true,
+      "expectReplacements": 1,
+      "expectNewContent": "Greetings world, world!"
+    },
+    {
+      "id": "no-match",
+      "original": "Nothing to see here.",
+      "operations": [
+        { "search": "world", "replace": "planet", "use_regex": false, "ignore_case": false }
+      ],
+      "expectModified": false,
+      "expectReplacements": 0,
+      "expectNewContent": "Nothing to see here."
+    },
+    {
+      "id": "invalid-regex-noop",
+      "original": "abc",
+      "operations": [
+        { "search": "[unterminated", "replace": "x", "use_regex": true, "ignore_case": false }
+      ],
+      "expectModified": false,
+      "expectReplacements": 0,
+      "expectNewContent": "abc"
+    }
+  ]
+}

--- a/crates/filesystem-core/fixtures/replace_content_golden.json
+++ b/crates/filesystem-core/fixtures/replace_content_golden.json
@@ -1,73 +1,103 @@
 {
-  "schema": "filesystem-core/replace_content_golden/v1",
-  "source": "src/handlers/replace-content.ts (applyReplaceOperation + createSearchRegex)",
-  "note": "BW2 offline pure residual deepen — proof_missing until CLI wire + tip differential allow-list expansion; route LegacyOptIn",
-  "cases": [
-    {
-      "id": "simple-literal-multi",
-      "original": "Hello world, world!",
-      "operations": [
-        { "search": "world", "replace": "planet", "use_regex": false, "ignore_case": false }
-      ],
-      "expectModified": true,
-      "expectReplacements": 2,
-      "expectNewContent": "Hello planet, planet!"
-    },
-    {
-      "id": "sequential-ops",
-      "original": "Hello world, world!",
-      "operations": [
-        { "search": "world", "replace": "galaxy", "use_regex": false, "ignore_case": false },
-        { "search": "galaxy", "replace": "universe", "use_regex": false, "ignore_case": false }
-      ],
-      "expectModified": true,
-      "expectReplacements": 4,
-      "expectNewContent": "Hello universe, universe!"
-    },
-    {
-      "id": "regex-capture-multiline-anchor",
-      "original": "Error: world not found.\nWarning: world might be deprecated.",
-      "operations": [
-        {
-          "search": "^(Error|Warning):",
-          "replace": "Log[$1]:",
-          "use_regex": true,
-          "ignore_case": false
-        }
-      ],
-      "expectModified": true,
-      "expectReplacements": 2,
-      "expectNewContent": "Log[Error]: world not found.\nLog[Warning]: world might be deprecated."
-    },
-    {
-      "id": "case-insensitive",
-      "original": "Hello world, world!",
-      "operations": [
-        { "search": "hello", "replace": "Greetings", "use_regex": false, "ignore_case": true }
-      ],
-      "expectModified": true,
-      "expectReplacements": 1,
-      "expectNewContent": "Greetings world, world!"
-    },
-    {
-      "id": "no-match",
-      "original": "Nothing to see here.",
-      "operations": [
-        { "search": "world", "replace": "planet", "use_regex": false, "ignore_case": false }
-      ],
-      "expectModified": false,
-      "expectReplacements": 0,
-      "expectNewContent": "Nothing to see here."
-    },
-    {
-      "id": "invalid-regex-noop",
-      "original": "abc",
-      "operations": [
-        { "search": "[unterminated", "replace": "x", "use_regex": true, "ignore_case": false }
-      ],
-      "expectModified": false,
-      "expectReplacements": 0,
-      "expectNewContent": "abc"
-    }
-  ]
+	"schema": "filesystem-core/replace_content_golden/v1",
+	"source": "src/handlers/replace-content.ts (applyReplaceOperation + createSearchRegex)",
+	"note": "BW2 offline pure residual deepen — proof_missing until CLI wire + tip differential allow-list expansion; route LegacyOptIn",
+	"cases": [
+		{
+			"id": "simple-literal-multi",
+			"original": "Hello world, world!",
+			"operations": [
+				{
+					"search": "world",
+					"replace": "planet",
+					"use_regex": false,
+					"ignore_case": false
+				}
+			],
+			"expectModified": true,
+			"expectReplacements": 2,
+			"expectNewContent": "Hello planet, planet!"
+		},
+		{
+			"id": "sequential-ops",
+			"original": "Hello world, world!",
+			"operations": [
+				{
+					"search": "world",
+					"replace": "galaxy",
+					"use_regex": false,
+					"ignore_case": false
+				},
+				{
+					"search": "galaxy",
+					"replace": "universe",
+					"use_regex": false,
+					"ignore_case": false
+				}
+			],
+			"expectModified": true,
+			"expectReplacements": 4,
+			"expectNewContent": "Hello universe, universe!"
+		},
+		{
+			"id": "regex-capture-multiline-anchor",
+			"original": "Error: world not found.\nWarning: world might be deprecated.",
+			"operations": [
+				{
+					"search": "^(Error|Warning):",
+					"replace": "Log[$1]:",
+					"use_regex": true,
+					"ignore_case": false
+				}
+			],
+			"expectModified": true,
+			"expectReplacements": 2,
+			"expectNewContent": "Log[Error]: world not found.\nLog[Warning]: world might be deprecated."
+		},
+		{
+			"id": "case-insensitive",
+			"original": "Hello world, world!",
+			"operations": [
+				{
+					"search": "hello",
+					"replace": "Greetings",
+					"use_regex": false,
+					"ignore_case": true
+				}
+			],
+			"expectModified": true,
+			"expectReplacements": 1,
+			"expectNewContent": "Greetings world, world!"
+		},
+		{
+			"id": "no-match",
+			"original": "Nothing to see here.",
+			"operations": [
+				{
+					"search": "world",
+					"replace": "planet",
+					"use_regex": false,
+					"ignore_case": false
+				}
+			],
+			"expectModified": false,
+			"expectReplacements": 0,
+			"expectNewContent": "Nothing to see here."
+		},
+		{
+			"id": "invalid-regex-noop",
+			"original": "abc",
+			"operations": [
+				{
+					"search": "[unterminated",
+					"replace": "x",
+					"use_regex": true,
+					"ignore_case": false
+				}
+			],
+			"expectModified": false,
+			"expectReplacements": 0,
+			"expectNewContent": "abc"
+		}
+	]
 }

--- a/crates/filesystem-core/src/apply_diff.rs
+++ b/crates/filesystem-core/src/apply_diff.rs
@@ -545,4 +545,56 @@ mod tests {
         assert!(result.success, "{:?}", result.error);
         assert_eq!(result.new_content.as_deref(), Some("1\ntwo\n3\n"));
     }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ApplyDiffGoldenFixture {
+        cases: Vec<ApplyDiffGoldenCase>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ApplyDiffGoldenCase {
+        id: String,
+        original: String,
+        diffs: Vec<DiffBlock>,
+        #[serde(rename = "expectSuccess")]
+        expect_success: bool,
+        #[serde(default, rename = "expectNewContent")]
+        expect_new_content: Option<String>,
+        #[serde(default, rename = "errorContains")]
+        error_contains: Option<String>,
+    }
+
+    /// Pure residual (BW3): bind `apply_diff_golden.json` via include_str! so
+    /// fixture drift fails cargo test. No CLI wire / route flip / authority.
+    #[test]
+    fn apply_diff_golden_fixture_cases() {
+        let raw = include_str!("../fixtures/apply_diff_golden.json");
+        let fixture: ApplyDiffGoldenFixture =
+            serde_json::from_str(raw).expect("parse apply_diff_golden.json");
+        assert!(!fixture.cases.is_empty(), "golden fixture must have cases");
+        for case in fixture.cases {
+            let result = apply_diffs_to_file_content(&case.original, &case.diffs);
+            assert_eq!(
+                result.success, case.expect_success,
+                "case {} success mismatch: {:?}",
+                case.id, result.error
+            );
+            if let Some(expected) = case.expect_new_content.as_deref() {
+                assert_eq!(
+                    result.new_content.as_deref(),
+                    Some(expected),
+                    "case {} content",
+                    case.id
+                );
+            }
+            if let Some(needle) = case.error_contains.as_deref() {
+                let err = result.error.as_deref().unwrap_or("");
+                assert!(
+                    err.contains(needle),
+                    "case {} expected error containing {needle:?}, got {err:?}",
+                    case.id
+                );
+            }
+        }
+    }
 }

--- a/crates/filesystem-core/src/apply_diff.rs
+++ b/crates/filesystem-core/src/apply_diff.rs
@@ -677,4 +677,34 @@ mod tests {
         assert_eq!(normalize_newlines("plain"), "plain");
     }
 
+
+    #[test]
+    fn bw7_lines_match_and_context_edges() {
+        // ignore_leading_whitespace uses trim_start on both sides
+        assert!(lines_match(Some("  alpha"), Some("alpha"), true));
+        assert!(lines_match(Some("alpha"), Some("  alpha"), true));
+        assert!(!lines_match(Some("  alpha"), Some("alpha"), false));
+        assert!(!lines_match(Some("alpha"), Some("ALPHA"), false));
+        // None pair always false (not both Some)
+        assert!(!lines_match(None, None, false));
+        assert!(!lines_match(Some("a"), None, true));
+        let lines = vec!["L1".into(), "L2".into(), "L3".into()];
+        let bad = get_context_around_line(&lines, 0, 1);
+        assert!(bad.contains("Invalid line number"), "{bad}");
+        let ctx = get_context_around_line(&lines, 1, 0);
+        assert!(ctx.contains("L1"), "{ctx}");
+        let multi = apply_indentation("x\ny", "--");
+        assert_eq!(multi, vec!["--x".to_string(), "--y".to_string()]);
+        assert!(has_valid_line_number_logic(5, 5));
+        assert!(!has_valid_line_number_logic(5, 4));
+    }
+
+    #[test]
+    fn bw7_escape_regex_and_normalize_newlines_matrix() {
+        assert_eq!(escape_regex("a.b*c"), "a\\.b\\*c");
+        assert_eq!(normalize_newlines("a\r\nb\rc"), "a\nb\nc");
+        assert_eq!(normalize_newlines("\r\n"), "\n");
+        assert_eq!(normalize_newlines("plain"), "plain");
+    }
+
 }

--- a/crates/filesystem-core/src/apply_diff.rs
+++ b/crates/filesystem-core/src/apply_diff.rs
@@ -597,4 +597,55 @@ mod tests {
             }
         }
     }
+
+
+    #[test]
+    fn validate_diff_block_insert_and_line_logic() {
+        assert!(!has_valid_line_number_logic(0, 1));
+        assert!(!has_valid_line_number_logic(2, 1));
+        assert!(has_valid_line_number_logic(1, 1));
+        assert!(has_valid_line_number_logic(1, 3));
+
+        let insert_ok = DiffBlock {
+            search: String::new(),
+            replace: "x".into(),
+            start_line: 2,
+            end_line: 1,
+            operation: Some(DiffOperation::Insert),
+        };
+        assert!(validate_diff_block(&insert_ok));
+        let insert_bad = DiffBlock {
+            search: "not-empty".into(),
+            replace: "x".into(),
+            start_line: 2,
+            end_line: 1,
+            operation: Some(DiffOperation::Insert),
+        };
+        assert!(!validate_diff_block(&insert_bad));
+        let replace_ok = DiffBlock {
+            search: "a".into(),
+            replace: "b".into(),
+            start_line: 1,
+            end_line: 1,
+            operation: None,
+        };
+        assert!(validate_diff_block(&replace_ok));
+        let replace_bad_start = DiffBlock {
+            search: "a".into(),
+            replace: "b".into(),
+            start_line: 0,
+            end_line: 1,
+            operation: None,
+        };
+        assert!(!validate_diff_block(&replace_bad_start));
+    }
+
+    #[test]
+    fn escape_regex_covers_remaining_specials() {
+        for ch in ['$', '(', ')', '*', '+', '.', '?', '[', '\\', ']', '^', '{', '|', '}'] {
+            let escaped = escape_regex(&ch.to_string());
+            assert_eq!(escaped, format!("\\{ch}"));
+        }
+        assert_eq!(escape_regex("plain"), "plain");
+    }
 }

--- a/crates/filesystem-core/src/apply_diff.rs
+++ b/crates/filesystem-core/src/apply_diff.rs
@@ -707,4 +707,69 @@ mod tests {
         assert_eq!(normalize_newlines("plain"), "plain");
     }
 
+
+    #[test]
+    fn bw8_validate_diff_block_insert_and_replace() {
+        let insert = DiffBlock {
+            search: String::new(),
+            replace: "new".into(),
+            start_line: 3,
+            end_line: 2,
+            operation: None,
+        };
+        assert!(insert.is_insert());
+        assert!(validate_diff_block(&insert));
+        let bad_insert = DiffBlock {
+            search: "not-empty".into(),
+            replace: "x".into(),
+            start_line: 3,
+            end_line: 2,
+            operation: None,
+        };
+        assert!(bad_insert.is_insert());
+        assert!(!validate_diff_block(&bad_insert));
+        let replace = DiffBlock {
+            search: "a".into(),
+            replace: "b".into(),
+            start_line: 1,
+            end_line: 1,
+            operation: None,
+        };
+        assert!(!replace.is_insert());
+        assert!(validate_diff_block(&replace));
+        assert!(!validate_diff_block(&DiffBlock {
+            search: "a".into(),
+            replace: "b".into(),
+            start_line: 0,
+            end_line: 1,
+            operation: None,
+        }));
+    }
+
+    #[test]
+    fn bw8_get_indentation_and_escape_all_specials() {
+        assert_eq!(get_indentation(None), "");
+        assert_eq!(get_indentation(Some("")), "");
+        assert_eq!(get_indentation(Some("\t  code")), "\t  ");
+        assert_eq!(get_indentation(Some("no-indent")), "");
+        // Full metachar set the pure residual escaper handles.
+        let specials = "$()*+.?[\\]^{|}";
+        let esc = escape_regex(specials);
+        for ch in ['$', '(', ')', '*', '+', '.', '?', '[', '\\', ']', '^', '{', '|', '}'] {
+            assert!(esc.contains(&format!("\\{ch}")), "missing escape for {ch}: {esc}");
+        }
+        assert_eq!(escape_regex("abc"), "abc");
+        assert_eq!(escape_regex("]"), "\\]");
+    }
+
+    #[test]
+    fn bw8_get_context_around_line_ellipsis_bounds() {
+        let lines: Vec<String> = (1..=10).map(|i| format!("L{i}")).collect();
+        let ctx = get_context_around_line(&lines, 5, 1);
+        assert!(ctx.contains("> 5"), "{ctx}");
+        assert!(ctx.contains("L5"), "{ctx}");
+        assert!(ctx.contains("..."), "{ctx}");
+        let ctx = get_context_around_line(&lines, 10, 2);
+        assert!(ctx.contains("> 10"), "{ctx}");
+    }
 }

--- a/crates/filesystem-core/src/apply_diff.rs
+++ b/crates/filesystem-core/src/apply_diff.rs
@@ -648,4 +648,33 @@ mod tests {
         }
         assert_eq!(escape_regex("plain"), "plain");
     }
+
+    #[test]
+    fn indentation_and_line_number_logic_pure() {
+        assert_eq!(get_indentation(Some("    foo")), "    ");
+        assert_eq!(get_indentation(Some("\tbar")), "\t");
+        assert_eq!(get_indentation(Some("baz")), "");
+        assert_eq!(get_indentation(None), "");
+        let lines = apply_indentation("a\nb", "  ");
+        assert_eq!(lines, vec!["  a".to_string(), "  b".to_string()]);
+        assert!(has_valid_line_number_logic(1, 1));
+        assert!(has_valid_line_number_logic(1, 3));
+        assert!(!has_valid_line_number_logic(0, 1));
+        assert!(!has_valid_line_number_logic(3, 1));
+        assert!(!has_valid_line_number_logic(-1, 2));
+        assert!(lines_match(Some("alpha"), Some("alpha"), false));
+        assert!(!lines_match(Some("alpha"), Some("ALPHA"), false));
+        assert!(lines_match(Some("  alpha"), Some("alpha"), true));
+        assert!(!lines_match(None, Some("x"), false));
+        let hay = vec!["alpha".into(), "beta".into(), "gamma".into()];
+        let ctx = get_context_around_line(&hay, 2, 1);
+        assert!(ctx.contains("alpha") || ctx.contains("beta") || ctx.contains("gamma"));
+    }
+
+    #[test]
+    fn normalize_newlines_crlf_to_lf() {
+        assert_eq!(normalize_newlines("a\r\nb\rc"), "a\nb\nc");
+        assert_eq!(normalize_newlines("plain"), "plain");
+    }
+
 }

--- a/crates/filesystem-core/src/apply_diff.rs
+++ b/crates/filesystem-core/src/apply_diff.rs
@@ -1,0 +1,548 @@
+//! Pure apply-diff engine (TS `src/utils/apply-diff-utils.ts` + `string-utils.ts`).
+//!
+//! Offline BW2 pure residual deepen: content transform + validation only (no I/O).
+//! Tool routing remains LegacyOptIn until route flip + differential_green (rej-010).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DiffOperation {
+    #[default]
+    Replace,
+    Insert,
+}
+
+impl DiffOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Replace => "replace",
+            Self::Insert => "insert",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffBlock {
+    pub search: String,
+    pub replace: String,
+    pub start_line: i64,
+    pub end_line: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<DiffOperation>,
+}
+
+impl DiffBlock {
+    fn operation_or_default(&self) -> DiffOperation {
+        self.operation.unwrap_or(DiffOperation::Replace)
+    }
+
+    /// Insert is encoded as `end_line == start_line - 1` (TS apply-diff contract).
+    fn is_insert(&self) -> bool {
+        self.end_line == self.start_line - 1
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffResult {
+    pub operation: String,
+    pub start_line: i64,
+    pub end_line: i64,
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyDiffResult {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new_content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_results: Option<Vec<DiffResult>>,
+}
+
+/// Escape regex specials — parity with TS `escapeRegex`.
+pub fn escape_regex(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '$' | '(' | ')' | '*' | '+' | '.' | '?' | '[' | '\\' | ']' | '^' | '{' | '|' | '}' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Leading whitespace of a line — parity with TS `getIndentation`.
+pub fn get_indentation(line: Option<&str>) -> String {
+    let Some(line) = line else {
+        return String::new();
+    };
+    line.chars()
+        .take_while(|c| c.is_whitespace())
+        .collect()
+}
+
+/// Apply indent prefix to each line — parity with TS `applyIndentation`.
+pub fn apply_indentation(content: &str, indent: &str) -> Vec<String> {
+    content
+        .split('\n')
+        .map(|line| format!("{indent}{line}"))
+        .collect()
+}
+
+/// Line equality with optional leading-ws ignore — parity with TS `linesMatch`.
+pub fn lines_match(
+    file_line: Option<&str>,
+    search_line: Option<&str>,
+    ignore_leading_whitespace: bool,
+) -> bool {
+    let (Some(file_line), Some(search_line)) = (file_line, search_line) else {
+        return false;
+    };
+    if ignore_leading_whitespace {
+        file_line.trim_start() == search_line.trim_start()
+    } else {
+        file_line == search_line
+    }
+}
+
+/// Context window around a 1-based line — parity with TS `getContextAroundLine`.
+pub fn get_context_around_line(lines: &[String], line_number: i64, context_size: usize) -> String {
+    if line_number < 1 {
+        return format!("Error: Invalid line number ({line_number}) provided for context.");
+    }
+
+    let line_usize = line_number as usize;
+    let start = line_usize.saturating_sub(1).saturating_sub(context_size);
+    let end = (line_usize + context_size).min(lines.len());
+    let mut context_lines: Vec<String> = Vec::new();
+
+    for i in start..end {
+        let current = i + 1;
+        let prefix = if current as i64 == line_number {
+            format!("> {current}")
+        } else {
+            format!("  {current}")
+        };
+        let content = lines.get(i).map(String::as_str).unwrap_or("");
+        context_lines.push(format!("{prefix} | {content}"));
+    }
+
+    if start > 0 {
+        context_lines.insert(0, "  ...".to_string());
+    }
+    if end < lines.len() {
+        context_lines.push("  ...".to_string());
+    }
+
+    context_lines.join("\n")
+}
+
+/// Structural validity of a potential diff block (fields + types via construction).
+pub fn has_valid_line_number_logic(start_line: i64, end_line: i64) -> bool {
+    if start_line <= 0 {
+        return false;
+    }
+    // TS rejects end_line < start_line for non-insert; insert uses end = start - 1
+    // and is validated separately via validate_diff_block.
+    if end_line < start_line {
+        return false;
+    }
+    true
+}
+
+pub fn validate_diff_block(diff: &DiffBlock) -> bool {
+    if diff.start_line <= 0 {
+        return false;
+    }
+    // Insert: end_line == start_line - 1 with empty search
+    if diff.is_insert() {
+        return diff.search.is_empty();
+    }
+    has_valid_line_number_logic(diff.start_line, diff.end_line)
+}
+
+pub fn validate_line_numbers(diff: &DiffBlock, lines: &[String]) -> Result<(), (String, String)> {
+    let start_line = diff.start_line;
+    let end_line = diff.end_line;
+
+    if start_line < 1 {
+        let error = format!("Invalid line numbers [{start_line}-{end_line}]");
+        let context = format!(
+            "File has {} lines total.\n{}",
+            lines.len(),
+            get_context_around_line(lines, 1, 3)
+        );
+        return Err((error, context));
+    }
+    // Insert: end_line == start_line - 1 with empty search (validated in validate_diff_block).
+    if diff.is_insert() {
+        if start_line as usize > lines.len() + 1 {
+            let error = format!("Invalid line numbers [{start_line}-{end_line}]");
+            let context = format!(
+                "File has {} lines total.\n{}",
+                lines.len(),
+                get_context_around_line(lines, start_line.min(lines.len() as i64).max(1), 3)
+            );
+            return Err((error, context));
+        }
+        return Ok(());
+    }
+    if end_line < start_line {
+        let error = format!("Invalid line numbers [{start_line}-{end_line}]");
+        let context = format!(
+            "File has {} lines total.\n{}",
+            lines.len(),
+            get_context_around_line(lines, start_line, 3)
+        );
+        return Err((error, context));
+    }
+    if end_line as usize > lines.len() {
+        let error = format!("Invalid line numbers [{start_line}-{end_line}]");
+        let context_line = start_line.min(lines.len() as i64).max(1);
+        let context = format!(
+            "File has {} lines total.\n{}",
+            lines.len(),
+            get_context_around_line(lines, context_line, 3)
+        );
+        return Err((error, context));
+    }
+    Ok(())
+}
+
+fn normalize_newlines(s: &str) -> String {
+    s.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+pub fn verify_content_match(diff: &DiffBlock, lines: &[String]) -> Result<(), (String, String)> {
+    if diff.is_insert() {
+        return Ok(());
+    }
+
+    let start_line = diff.start_line;
+    let end_line = diff.end_line;
+    if start_line < 1 || end_line < start_line || end_line as usize > lines.len() {
+        return Err((
+            format!(
+                "Internal Error: Invalid line numbers [{start_line}-{end_line}] in verifyContentMatch."
+            ),
+            String::new(),
+        ));
+    }
+
+    let start_idx = (start_line as usize) - 1;
+    let end_idx = end_line as usize;
+    let actual_block = lines[start_idx..end_idx].join("\n");
+    let normalized_search = normalize_newlines(&diff.search).trim().to_string();
+    let normalized_actual = normalize_newlines(&actual_block).trim().to_string();
+
+    if normalized_actual != normalized_search {
+        let error = format!(
+            "Content mismatch at lines {start_line}-{end_line}. Expected content does not match actual content."
+        );
+        let context = format!(
+            "--- EXPECTED (Search Block) ---\n{}\n--- ACTUAL (Lines {start_line}-{end_line}) ---\n{}\n--- DIFF ---\nExpected length: {}, Actual length: {}",
+            diff.search,
+            actual_block,
+            diff.search.len(),
+            actual_block.len()
+        );
+        return Err((error, context));
+    }
+    Ok(())
+}
+
+/// Mutate `lines` applying one validated diff (bottom-up caller order).
+pub fn apply_single_valid_diff(lines: &mut Vec<String>, diff: &DiffBlock) {
+    let replace_lines: Vec<String> = normalize_newlines(&diff.replace)
+        .split('\n')
+        .map(str::to_string)
+        .collect();
+    let start_idx = (diff.start_line as usize).saturating_sub(1);
+
+    if diff.is_insert() {
+        if start_idx <= lines.len() {
+            lines.splice(start_idx..start_idx, replace_lines);
+        }
+        return;
+    }
+
+    let end_idx = (diff.end_line as usize).min(lines.len());
+    if start_idx < lines.len() && end_idx >= start_idx && end_idx <= lines.len() {
+        let delete_count = end_idx - start_idx;
+        lines.splice(start_idx..start_idx + delete_count, replace_lines);
+    }
+}
+
+fn record_failed(
+    results: &mut Vec<DiffResult>,
+    errors: &mut Vec<String>,
+    diff: &DiffBlock,
+    error: String,
+    context: Option<String>,
+) {
+    results.push(DiffResult {
+        operation: diff.operation_or_default().as_str().to_string(),
+        start_line: diff.start_line,
+        end_line: diff.end_line,
+        success: false,
+        error: Some(error.clone()),
+        context,
+    });
+    errors.push(error);
+}
+
+/// Apply ordered diffs to in-memory file content — pure SSOT for MCP apply_diff.
+pub fn apply_diffs_to_file_content(original_content: &str, diffs: &[DiffBlock]) -> ApplyDiffResult {
+    let valid: Vec<&DiffBlock> = diffs.iter().filter(|d| validate_diff_block(d)).collect();
+    if valid.is_empty() {
+        return ApplyDiffResult {
+            success: true,
+            new_content: Some(original_content.to_string()),
+            error: None,
+            context: None,
+            diff_results: None,
+        };
+    }
+
+    let mut lines: Vec<String> = original_content.split('\n').map(str::to_string).collect();
+    let mut diff_results: Vec<DiffResult> = Vec::new();
+    let mut error_messages: Vec<String> = Vec::new();
+    let mut has_errors = false;
+
+    // Apply bottom-up (descending end_line) so earlier indices stay stable.
+    let mut ordered = valid;
+    ordered.sort_by(|a, b| b.end_line.cmp(&a.end_line));
+
+    for diff in ordered {
+        if let Err((error, context)) = validate_line_numbers(diff, &lines) {
+            record_failed(
+                &mut diff_results,
+                &mut error_messages,
+                diff,
+                error,
+                Some(context),
+            );
+            has_errors = true;
+            continue;
+        }
+
+        if diff.is_insert() && !diff.search.is_empty() {
+            record_failed(
+                &mut diff_results,
+                &mut error_messages,
+                diff,
+                "Insert operations must have empty search string".into(),
+                Some(format!(
+                    "Invalid insert operation at line {}",
+                    diff.start_line
+                )),
+            );
+            has_errors = true;
+            continue;
+        }
+
+        if let Err((error, context)) = verify_content_match(diff, &lines) {
+            record_failed(
+                &mut diff_results,
+                &mut error_messages,
+                diff,
+                error,
+                if context.is_empty() {
+                    None
+                } else {
+                    Some(context)
+                },
+            );
+            has_errors = true;
+            continue;
+        }
+
+        apply_single_valid_diff(&mut lines, diff);
+        diff_results.push(DiffResult {
+            operation: diff.operation_or_default().as_str().to_string(),
+            start_line: diff.start_line,
+            end_line: diff.end_line,
+            success: true,
+            error: None,
+            context: Some(format!(
+                "Successfully applied {} at lines {}-{}",
+                diff.operation_or_default().as_str(),
+                diff.start_line,
+                diff.end_line
+            )),
+        });
+    }
+
+    if has_errors {
+        let success_count = diff_results.iter().filter(|r| r.success).count();
+        ApplyDiffResult {
+            success: false,
+            new_content: None,
+            error: Some(format!(
+                "Some diffs failed: {}",
+                error_messages.join("; ")
+            )),
+            context: Some(format!(
+                "Applied {success_count} of {} diffs successfully",
+                diff_results.len()
+            )),
+            diff_results: Some(diff_results),
+        }
+    } else {
+        ApplyDiffResult {
+            success: true,
+            new_content: Some(lines.join("\n")),
+            error: None,
+            context: None,
+            diff_results: Some(diff_results),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_regex_escapes_specials() {
+        assert_eq!(escape_regex("a+b"), r"a\+b");
+        assert_eq!(escape_regex("file.txt"), r"file\.txt");
+    }
+
+    #[test]
+    fn indentation_helpers() {
+        assert_eq!(get_indentation(Some("  foo")), "  ");
+        assert_eq!(get_indentation(None), "");
+        assert_eq!(
+            apply_indentation("a\nb", "  "),
+            vec!["  a".to_string(), "  b".to_string()]
+        );
+        assert!(lines_match(Some("  x"), Some("x"), true));
+        assert!(!lines_match(Some("  x"), Some("x"), false));
+    }
+
+    #[test]
+    fn context_around_middle_line() {
+        let lines: Vec<String> = ["Line 1", "Line 2", "Line 3", "Line 4", "Line 5"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let context = get_context_around_line(&lines, 3, 1);
+        assert_eq!(
+            context,
+            "  ...\n  2 | Line 2\n> 3 | Line 3\n  4 | Line 4\n  ..."
+        );
+    }
+
+    #[test]
+    fn context_invalid_line() {
+        let lines = vec!["a".to_string()];
+        assert!(get_context_around_line(&lines, 0, 1).contains("Error: Invalid line number"));
+    }
+
+    #[test]
+    fn replace_single_line_content() {
+        let original = "export const version = '1.0.0';\n";
+        let diffs = vec![DiffBlock {
+            search: "export const version = '1.0.0';".into(),
+            replace: "export const version = '1.0.1';".into(),
+            start_line: 1,
+            end_line: 1,
+            operation: Some(DiffOperation::Replace),
+        }];
+        let result = apply_diffs_to_file_content(original, &diffs);
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            result.new_content.as_deref(),
+            Some("export const version = '1.0.1';\n")
+        );
+    }
+
+    #[test]
+    fn content_mismatch_fails() {
+        let original = "aaa\nbbb\nccc\n";
+        let diffs = vec![DiffBlock {
+            search: "xxx".into(),
+            replace: "yyy".into(),
+            start_line: 2,
+            end_line: 2,
+            operation: None,
+        }];
+        let result = apply_diffs_to_file_content(original, &diffs);
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Content mismatch"));
+    }
+
+    #[test]
+    fn insert_at_line() {
+        let original = "a\nc\n";
+        let diffs = vec![DiffBlock {
+            search: String::new(),
+            replace: "b".into(),
+            start_line: 2,
+            end_line: 1, // insert: end = start - 1
+            operation: Some(DiffOperation::Insert),
+        }];
+        let result = apply_diffs_to_file_content(original, &diffs);
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.new_content.as_deref(), Some("a\nb\nc\n"));
+    }
+
+    #[test]
+    fn empty_valid_set_returns_original() {
+        let original = "unchanged\n";
+        // Invalid block filtered out → empty valid set
+        let diffs = vec![DiffBlock {
+            search: "x".into(),
+            replace: "y".into(),
+            start_line: 5,
+            end_line: 1,
+            operation: None,
+        }];
+        let result = apply_diffs_to_file_content(original, &diffs);
+        assert!(result.success);
+        assert_eq!(result.new_content.as_deref(), Some(original));
+    }
+
+    #[test]
+    fn multi_replace_bottom_up() {
+        let original = "one\ntwo\nthree\n";
+        let diffs = vec![
+            DiffBlock {
+                search: "one".into(),
+                replace: "1".into(),
+                start_line: 1,
+                end_line: 1,
+                operation: None,
+            },
+            DiffBlock {
+                search: "three".into(),
+                replace: "3".into(),
+                start_line: 3,
+                end_line: 3,
+                operation: None,
+            },
+        ];
+        let result = apply_diffs_to_file_content(original, &diffs);
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.new_content.as_deref(), Some("1\ntwo\n3\n"));
+    }
+}

--- a/crates/filesystem-core/src/audit.rs
+++ b/crates/filesystem-core/src/audit.rs
@@ -318,4 +318,25 @@ mod tests {
             .unwrap_or("")
             .contains("snapshot_exceeds_max_bytes"));
     }
+
+
+    #[test]
+    fn content_hash_is_stable_sha256_hex() {
+        let a = content_hash("hello");
+        let b = content_hash("hello");
+        let c = content_hash("hello!");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|ch| ch.is_ascii_hexdigit()));
+        let path = audit_ledger_path(Path::new("/tmp/proj"));
+        let path_s = path.to_string_lossy();
+        assert!(
+            path_s.contains("audit") || path_s.contains("ledger") || path.extension().is_some(),
+            "unexpected ledger path {path_s}"
+        );
+        let snap = rollback_snapshot_path(Path::new("/tmp/proj"), "op1", "src/a.ts");
+        let snap_s = snap.to_string_lossy();
+        assert!(snap_s.contains("op1"), "{snap_s}");
+    }
 }

--- a/crates/filesystem-core/src/audit.rs
+++ b/crates/filesystem-core/src/audit.rs
@@ -354,4 +354,17 @@ mod tests {
         assert!(ledger.ends_with(".filesystem-mcp/audit.jsonl") || ledger.to_string_lossy().contains("audit"));
     }
 
+
+    #[test]
+    fn bw8_content_hash_empty_sha256_and_paths() {
+        assert_eq!(
+            content_hash(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_ne!(content_hash("A"), content_hash("a"));
+        let snap = rollback_snapshot_path(Path::new("/r"), "op-99", "nested/x.ts");
+        let s = snap.to_string_lossy();
+        assert!(s.contains("op-99"), "{s}");
+        assert!(s.contains("nested") || s.contains("x.ts"), "{s}");
+    }
 }

--- a/crates/filesystem-core/src/audit.rs
+++ b/crates/filesystem-core/src/audit.rs
@@ -339,4 +339,19 @@ mod tests {
         let snap_s = snap.to_string_lossy();
         assert!(snap_s.contains("op1"), "{snap_s}");
     }
+
+    #[test]
+    fn bw7_content_hash_empty_and_differs() {
+        let empty = content_hash("");
+        assert_eq!(empty.len(), 64);
+        assert_eq!(content_hash(""), empty);
+        assert_ne!(content_hash("a"), content_hash("b"));
+        assert_eq!(
+            content_hash("hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+        let ledger = audit_ledger_path(Path::new("/tmp/root"));
+        assert!(ledger.ends_with(".filesystem-mcp/audit.jsonl") || ledger.to_string_lossy().contains("audit"));
+    }
+
 }

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod apply_diff;
 pub mod audit;
 pub mod content;
+pub mod mutations;
 pub mod search;
 pub mod walk;
 
@@ -17,6 +18,10 @@ pub use apply_diff::{
 pub use content::{
     delete_items, read_content, stat_items, write_content, DeleteItemsResult, ReadContentOptions,
     ReadContentResult, ReadFormat, StatItemResult, WriteContentResult, WriteItem, CONTENT_ROUTE,
+};
+pub use mutations::{
+    copy_items, create_directories, move_items, CreateDirResult, TransferOp, TransferResult,
+    MUTATIONS_ROUTE,
 };
 pub use audit::{
     append_audit_batch, append_audit_batch_with_limit, content_hash, generate_operation_id,

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -3,12 +3,18 @@
 pub mod apply_diff;
 pub mod audit;
 pub mod content;
+pub mod mode_policy;
 pub mod mutations;
 pub mod replace_content;
 pub mod search;
 pub mod walk;
 
 pub use walk::format_entry_stats;
+pub use mode_policy::{
+    evaluate_chmod_gate, evaluate_chown_gate, format_mode_octal, is_project_root_path,
+    is_valid_octal_mode_string, is_valid_ownership, normalize_display_path, parse_octal_mode,
+    ModePolicyDecision, CHMOD_ROOT_DENIED, CHOWN_ROOT_DENIED,
+};
 
 pub use apply_diff::{
     apply_diffs_to_file_content, apply_indentation, apply_single_valid_diff, escape_regex,

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -237,4 +237,18 @@ mod tests {
         assert!(is_absolute_user_path("/abs/path"));
         assert!(!is_absolute_user_path("rel/path"));
     }
+
+
+    #[test]
+    fn bw8_is_path_inside_sibling_and_prefix_trap() {
+        let root = PathBuf::from("/proj/app");
+        assert!(is_path_inside(Path::new("/proj/app"), &root));
+        assert!(is_path_inside(Path::new("/proj/app/src"), &root));
+        assert!(!is_path_inside(Path::new("/proj/app2"), &root));
+        assert!(!is_path_inside(Path::new("/proj"), &root));
+        assert!(looks_like_windows_absolute("E:\\\\x") || looks_like_windows_absolute("E:\\x"));
+        assert!(!looks_like_windows_absolute(":/x"));
+        assert!(!looks_like_windows_absolute(""));
+        assert!(!is_absolute_user_path(""));
+    }
 }

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Root-scoped filesystem path policy and search engine.
 
+pub mod apply_diff;
 pub mod audit;
 pub mod content;
 pub mod search;
@@ -7,6 +8,12 @@ pub mod walk;
 
 pub use walk::format_entry_stats;
 
+pub use apply_diff::{
+    apply_diffs_to_file_content, apply_indentation, apply_single_valid_diff, escape_regex,
+    get_context_around_line, get_indentation, has_valid_line_number_logic, lines_match,
+    validate_diff_block, validate_line_numbers, verify_content_match, ApplyDiffResult, DiffBlock,
+    DiffOperation, DiffResult,
+};
 pub use content::{
     delete_items, read_content, stat_items, write_content, DeleteItemsResult, ReadContentOptions,
     ReadContentResult, ReadFormat, StatItemResult, WriteContentResult, WriteItem, CONTENT_ROUTE,

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -209,4 +209,16 @@ mod tests {
         let result = resolve_path("escape-link/secret.txt", &root);
         assert_eq!(result.unwrap_err().code, PolicyErrorCode::InvalidRequest);
     }
+
+    #[test]
+    fn looks_like_windows_absolute_and_absolute_user_path() {
+        assert!(looks_like_windows_absolute("C:\\Users\\x"));
+        assert!(looks_like_windows_absolute("c:/Users/x"));
+        assert!(!looks_like_windows_absolute("/usr/bin"));
+        assert!(!looks_like_windows_absolute("relative/path"));
+        assert!(is_absolute_user_path("/abs"));
+        assert!(is_absolute_user_path("C:\\abs"));
+        assert!(!is_absolute_user_path("rel"));
+    }
+
 }

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -221,4 +221,20 @@ mod tests {
         assert!(!is_absolute_user_path("rel"));
     }
 
+
+
+    #[test]
+    fn bw7_path_inside_and_windows_absolute_edges() {
+        let root = PathBuf::from("/mock/project/root");
+        assert!(is_path_inside(&root, &root));
+        assert!(is_path_inside(&root.join("x"), &root));
+        assert!(!is_path_inside(Path::new("/mock/project/root2"), &root));
+        assert!(looks_like_windows_absolute("D:/x"));
+        assert!(looks_like_windows_absolute("Z:\\"));
+        assert!(!looks_like_windows_absolute("C"));
+        assert!(!looks_like_windows_absolute("1:\\nope"));
+        assert!(is_absolute_user_path("/"));
+        assert!(is_absolute_user_path("/abs/path"));
+        assert!(!is_absolute_user_path("rel/path"));
+    }
 }

--- a/crates/filesystem-core/src/lib.rs
+++ b/crates/filesystem-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod apply_diff;
 pub mod audit;
 pub mod content;
 pub mod mutations;
+pub mod replace_content;
 pub mod search;
 pub mod walk;
 
@@ -22,6 +23,10 @@ pub use content::{
 pub use mutations::{
     copy_items, create_directories, move_items, CreateDirResult, TransferOp, TransferResult,
     MUTATIONS_ROUTE,
+};
+pub use replace_content::{
+    apply_operations_to_content, apply_replace_operation, build_search_pattern, create_search_regex,
+    needs_multiline, ApplyReplaceResult, ReplaceOperation, REPLACE_CONTENT_ROUTE,
 };
 pub use audit::{
     append_audit_batch, append_audit_batch_with_limit, content_hash, generate_operation_id,

--- a/crates/filesystem-core/src/mode_policy.rs
+++ b/crates/filesystem-core/src/mode_policy.rs
@@ -1,0 +1,229 @@
+//! Pure chmod/chown mode & ownership arg policy (parity with handlers/chmod-items.ts
+//! and handlers/chown-items.ts validation surface).
+//!
+//! Offline bulk residual (FLEET-BULK-FILESYSTEM-MCP-v1). I/O residual
+//! (fs.chmod/chown) remains product effect — pure parse/validate only.
+//! authority_rust=false; no route flip; no ts_deleted.
+
+/// Mode must be an octal string like `755` or `0755` (3–4 digits, 0–7 only).
+#[must_use]
+pub fn is_valid_octal_mode_string(mode: &str) -> bool {
+    let len = mode.len();
+    if !(3..=4).contains(&len) {
+        return false;
+    }
+    mode.bytes().all(|b| (b'0'..=b'7').contains(&b))
+}
+
+/// Parse octal mode string to numeric mode bits (base-8).
+///
+/// Returns `None` when the string is not a valid 3–4 digit octal mode.
+#[must_use]
+pub fn parse_octal_mode(mode: &str) -> Option<u32> {
+    if !is_valid_octal_mode_string(mode) {
+        return None;
+    }
+    u32::from_str_radix(mode, 8).ok()
+}
+
+/// Format permission bits as a 3-digit octal string (mode & 0o777).
+///
+/// Parity with stats-utils.ts: `(stats.mode & 0o777).toString(8).padStart(3, '0')`.
+#[must_use]
+pub fn format_mode_octal(mode: u32) -> String {
+    format!("{:03o}", mode & 0o777)
+}
+
+/// Normalize display path to forward slashes (handler pathOutput).
+#[must_use]
+pub fn normalize_display_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+/// True when the resolved absolute path equals the project root (forbid mutation).
+///
+/// Mirrors: `if (targetPath === PROJECT_ROOT) return error … not allowed`.
+#[must_use]
+pub fn is_project_root_path(resolved: &std::path::Path, root: &std::path::Path) -> bool {
+    resolved == root
+}
+
+/// Pure chown identity validation: uid/gid must be non-negative integers
+/// representable as i64 (TS z.number().int()).
+#[must_use]
+pub fn is_valid_ownership_id(id: i64) -> bool {
+    id >= 0
+}
+
+/// Validate chown pair.
+#[must_use]
+pub fn is_valid_ownership(uid: i64, gid: i64) -> bool {
+    is_valid_ownership_id(uid) && is_valid_ownership_id(gid)
+}
+
+/// Root-mutation denial message (chmod).
+pub const CHMOD_ROOT_DENIED: &str = "Changing permissions of the project root is not allowed.";
+
+/// Root-mutation denial message (chown) — shared policy class.
+pub const CHOWN_ROOT_DENIED: &str = "Changing ownership of the project root is not allowed.";
+
+/// Build chmod result shape for a pure policy decision (no I/O).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModePolicyDecision {
+    pub path: String,
+    pub allowed: bool,
+    pub mode: Option<u32>,
+    pub mode_string: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Pure pre-I/O gate for a single chmod path + mode string.
+#[must_use]
+pub fn evaluate_chmod_gate(
+    relative_path: &str,
+    mode_string: &str,
+    resolved_is_root: bool,
+) -> ModePolicyDecision {
+    let path = normalize_display_path(relative_path);
+    if resolved_is_root {
+        return ModePolicyDecision {
+            path,
+            allowed: false,
+            mode: None,
+            mode_string: None,
+            error: Some(CHMOD_ROOT_DENIED.into()),
+        };
+    }
+    match parse_octal_mode(mode_string) {
+        Some(mode) => ModePolicyDecision {
+            path,
+            allowed: true,
+            mode: Some(mode),
+            mode_string: Some(mode_string.to_string()),
+            error: None,
+        },
+        None => ModePolicyDecision {
+            path,
+            allowed: false,
+            mode: None,
+            mode_string: None,
+            error: Some(format!(
+                "Mode must be an octal string like '755' or '0755': got '{mode_string}'"
+            )),
+        },
+    }
+}
+
+/// Pure pre-I/O gate for a single chown path + uid/gid.
+#[must_use]
+pub fn evaluate_chown_gate(
+    relative_path: &str,
+    uid: i64,
+    gid: i64,
+    resolved_is_root: bool,
+) -> ModePolicyDecision {
+    let path = normalize_display_path(relative_path);
+    if resolved_is_root {
+        return ModePolicyDecision {
+            path,
+            allowed: false,
+            mode: None,
+            mode_string: None,
+            error: Some(CHOWN_ROOT_DENIED.into()),
+        };
+    }
+    if !is_valid_ownership(uid, gid) {
+        return ModePolicyDecision {
+            path,
+            allowed: false,
+            mode: None,
+            mode_string: None,
+            error: Some("UID/GID must be non-negative integers".into()),
+        };
+    }
+    ModePolicyDecision {
+        path,
+        allowed: true,
+        mode: None,
+        mode_string: Some(format!("{uid}:{gid}")),
+        error: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn octal_mode_valid_matrix() {
+        assert!(is_valid_octal_mode_string("755"));
+        assert!(is_valid_octal_mode_string("644"));
+        assert!(is_valid_octal_mode_string("0755"));
+        assert!(is_valid_octal_mode_string("0000"));
+        assert!(!is_valid_octal_mode_string("75"));
+        assert!(!is_valid_octal_mode_string("75555"));
+        assert!(!is_valid_octal_mode_string("789"));
+        assert!(!is_valid_octal_mode_string("75a"));
+        assert!(!is_valid_octal_mode_string(""));
+    }
+
+    #[test]
+    fn parse_octal_mode_values() {
+        assert_eq!(parse_octal_mode("755"), Some(0o755));
+        assert_eq!(parse_octal_mode("644"), Some(0o644));
+        assert_eq!(parse_octal_mode("0755"), Some(0o755));
+        assert_eq!(parse_octal_mode("000"), Some(0));
+        assert_eq!(parse_octal_mode("888"), None);
+        assert_eq!(parse_octal_mode("12"), None);
+    }
+
+    #[test]
+    fn format_mode_masks_to_9_bits() {
+        assert_eq!(format_mode_octal(0o100644), "644");
+        assert_eq!(format_mode_octal(0o755), "755");
+        assert_eq!(format_mode_octal(0o7), "007");
+    }
+
+    #[test]
+    fn normalize_display_path_slashes() {
+        assert_eq!(normalize_display_path(r"a\b\c"), "a/b/c");
+        assert_eq!(normalize_display_path("a/b"), "a/b");
+    }
+
+    #[test]
+    fn project_root_detection() {
+        let root = Path::new("/proj");
+        assert!(is_project_root_path(Path::new("/proj"), root));
+        assert!(!is_project_root_path(Path::new("/proj/src"), root));
+    }
+
+    #[test]
+    fn chmod_gate_root_and_bad_mode() {
+        let denied = evaluate_chmod_gate(".", "755", true);
+        assert!(!denied.allowed);
+        assert_eq!(denied.error.as_deref(), Some(CHMOD_ROOT_DENIED));
+
+        let bad = evaluate_chmod_gate("a.txt", "999", false);
+        assert!(!bad.allowed);
+        assert!(bad.error.as_ref().unwrap().contains("octal"));
+
+        let ok = evaluate_chmod_gate(r"dir\file", "644", false);
+        assert!(ok.allowed);
+        assert_eq!(ok.mode, Some(0o644));
+        assert_eq!(ok.path, "dir/file");
+    }
+
+    #[test]
+    fn chown_gate_matrix() {
+        assert!(is_valid_ownership(0, 0));
+        assert!(!is_valid_ownership(-1, 0));
+        let denied = evaluate_chown_gate(".", 0, 0, true);
+        assert!(!denied.allowed);
+        let ok = evaluate_chown_gate("x", 501, 20, false);
+        assert!(ok.allowed);
+        assert_eq!(ok.mode_string.as_deref(), Some("501:20"));
+        let bad = evaluate_chown_gate("x", -1, 0, false);
+        assert!(!bad.allowed);
+    }
+}

--- a/crates/filesystem-core/src/mode_policy.rs
+++ b/crates/filesystem-core/src/mode_policy.rs
@@ -226,4 +226,51 @@ mod tests {
         let bad = evaluate_chown_gate("x", -1, 0, false);
         assert!(!bad.allowed);
     }
+
+    #[test]
+    fn residual_mode_ownership_edges() {
+        // length bounds: only 3–4 digits
+        assert!(!is_valid_octal_mode_string(""));
+        assert!(!is_valid_octal_mode_string("12"));
+        assert!(!is_valid_octal_mode_string("12345"));
+        assert!(is_valid_octal_mode_string("000"));
+        assert!(is_valid_octal_mode_string("0777"));
+        // digit class 0–7 only; no whitespace
+        assert!(!is_valid_octal_mode_string(" 755"));
+        assert!(!is_valid_octal_mode_string("755 "));
+        assert!(!is_valid_octal_mode_string("78a"));
+        assert!(!is_valid_octal_mode_string("089"));
+        assert_eq!(parse_octal_mode(""), None);
+        assert_eq!(parse_octal_mode("xyz"), None);
+        assert_eq!(parse_octal_mode("0777"), Some(0o777));
+        // format: mask to 9 bits; zero pad
+        assert_eq!(format_mode_octal(0), "000");
+        assert_eq!(format_mode_octal(0o7777), "777");
+        // ownership: negative / ok
+        assert!(!is_valid_ownership_id(-1));
+        assert!(is_valid_ownership_id(0));
+        assert!(is_valid_ownership_id(i64::MAX));
+        assert!(!is_valid_ownership(-1, 0));
+        assert!(!is_valid_ownership(0, -1));
+        assert!(is_valid_ownership(0, 0));
+        // display path: backslash → forward slash only (no empty→dot)
+        assert_eq!(normalize_display_path(""), "");
+        let four_bs: String = std::iter::repeat('\\').take(4).collect();
+        assert_eq!(normalize_display_path(&four_bs), "////");
+        let a_bs_b: String = ['a', '\\', '\\', 'b'].into_iter().collect();
+        assert_eq!(normalize_display_path(&a_bs_b), "a//b");
+        // project root equality (not canonicalize)
+        let root = Path::new("/proj");
+        assert!(is_project_root_path(root, root));
+        assert!(!is_project_root_path(Path::new("/other"), root));
+        assert!(!is_project_root_path(Path::new("/proj/src"), root));
+        // chmod gate: 4-digit leading zero allowed
+        let ok4 = evaluate_chmod_gate("f", "0644", false);
+        assert!(ok4.allowed);
+        assert_eq!(ok4.mode, Some(0o644));
+        // chown gate root still denied even with valid ids
+        let denied = evaluate_chown_gate(".", 0, 0, true);
+        assert!(!denied.allowed);
+        assert_eq!(denied.error.as_deref(), Some(CHOWN_ROOT_DENIED));
+    }
 }

--- a/crates/filesystem-core/src/mutations.rs
+++ b/crates/filesystem-core/src/mutations.rs
@@ -1,0 +1,599 @@
+//! Root-scoped create / move / copy mutations (TS handlers under `src/handlers/`).
+//!
+//! Offline BW2 pure residual deepen: filesystem effects under `resolve_path` policy only.
+//! Tool routing remains LegacyOptIn until CLI wire + differential_green (rej-010).
+//! No authority_rust / ts_deleted claims.
+
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::resolve_path;
+
+pub const MUTATIONS_ROUTE: &str = "rust-mutations";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDirResult {
+    pub path: String,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferResult {
+    pub source: String,
+    pub destination: String,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferOp {
+    pub source: String,
+    pub destination: String,
+}
+
+fn normalize_display_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => a == b,
+    }
+}
+
+fn display_resolved(path: &Path) -> String {
+    path.display().to_string()
+}
+
+/// Create directories (including intermediate parents) under `root`.
+/// Parity intent with TS `create_directories` handler.
+pub fn create_directories(root: &Path, paths: &[String]) -> Vec<CreateDirResult> {
+    paths
+        .iter()
+        .map(|relative| create_single_directory(root, relative))
+        .collect()
+}
+
+fn create_single_directory(root: &Path, relative_path: &str) -> CreateDirResult {
+    let path_output = normalize_display_path(relative_path);
+    let resolved = match resolve_path(relative_path, root) {
+        Ok(path) => path,
+        Err(error) => {
+            return CreateDirResult {
+                path: path_output,
+                success: false,
+                note: None,
+                error: Some(error.message),
+                resolved_path: Some("Resolution failed".into()),
+            };
+        }
+    };
+
+    if paths_equal(&resolved, root) {
+        return CreateDirResult {
+            path: path_output,
+            success: false,
+            note: None,
+            error: Some("Creating the project root is not allowed.".into()),
+            resolved_path: Some(display_resolved(&resolved)),
+        };
+    }
+
+    match fs::create_dir_all(&resolved) {
+        Ok(()) => CreateDirResult {
+            path: path_output,
+            success: true,
+            note: None,
+            error: None,
+            resolved_path: Some(display_resolved(&resolved)),
+        },
+        Err(error) => handle_create_error(path_output, &resolved, relative_path, error),
+    }
+}
+
+fn handle_create_error(
+    path_output: String,
+    resolved: &Path,
+    relative_path: &str,
+    error: std::io::Error,
+) -> CreateDirResult {
+    // If something already exists at the path, mirror TS EEXIST handling.
+    if let Ok(meta) = fs::metadata(resolved) {
+        if meta.is_dir() {
+            return CreateDirResult {
+                path: path_output,
+                success: true,
+                note: Some("Directory already exists"),
+                error: None,
+                resolved_path: Some(display_resolved(resolved)),
+            };
+        }
+        return CreateDirResult {
+            path: path_output,
+            success: false,
+            note: None,
+            error: Some("Path exists but is not a directory".into()),
+            resolved_path: Some(display_resolved(resolved)),
+        };
+    }
+
+    let message = match error.kind() {
+        std::io::ErrorKind::PermissionDenied => {
+            format!("Permission denied creating directory: {error}")
+        }
+        _ => format!("Failed to create directory: {error}"),
+    };
+    // Keep relative_path available for future message tuning / debug.
+    let _ = relative_path;
+
+    CreateDirResult {
+        path: path_output,
+        success: false,
+        note: None,
+        error: Some(message),
+        resolved_path: Some(display_resolved(resolved)),
+    }
+}
+
+/// Move or rename items under `root`. Parity intent with TS `move_items`.
+pub fn move_items(root: &Path, operations: &[TransferOp]) -> Vec<TransferResult> {
+    operations
+        .iter()
+        .map(|op| move_single(root, op))
+        .collect()
+}
+
+fn move_single(root: &Path, op: &TransferOp) -> TransferResult {
+    let source_output = normalize_display_path(&op.source);
+    let dest_output = normalize_display_path(&op.destination);
+
+    if op.source.is_empty() || op.destination.is_empty() {
+        return TransferResult {
+            source: if source_output.is_empty() {
+                "undefined".into()
+            } else {
+                source_output
+            },
+            destination: if dest_output.is_empty() {
+                "undefined".into()
+            } else {
+                dest_output
+            },
+            success: false,
+            error: Some("Invalid operation: source and destination must be defined.".into()),
+        };
+    }
+
+    let source_abs = match resolve_path(&op.source, root) {
+        Ok(path) => path,
+        Err(error) => {
+            return TransferResult {
+                source: source_output,
+                destination: dest_output,
+                success: false,
+                error: Some(error.message),
+            };
+        }
+    };
+    let dest_abs = match resolve_path(&op.destination, root) {
+        Ok(path) => path,
+        Err(error) => {
+            return TransferResult {
+                source: source_output,
+                destination: dest_output,
+                success: false,
+                error: Some(error.message),
+            };
+        }
+    };
+
+    if paths_equal(&source_abs, root) {
+        return TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: false,
+            error: Some("Moving the project root is not allowed.".into()),
+        };
+    }
+
+    if !source_abs.exists() {
+        return TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: false,
+            error: Some(format!("Source path not found: {}", op.source)),
+        };
+    }
+
+    if let Some(dest_dir) = dest_abs.parent() {
+        let source_dir = source_abs.parent();
+        let needs_mkdir = dest_dir != root
+            && source_dir.map(|sd| sd != dest_dir).unwrap_or(true)
+            && !dest_dir.as_os_str().is_empty();
+        if needs_mkdir {
+            if let Err(error) = fs::create_dir_all(dest_dir) {
+                // Ignore already-exists race; surface other mkdir failures.
+                if !dest_dir.is_dir() {
+                    return TransferResult {
+                        source: source_output,
+                        destination: dest_output,
+                        success: false,
+                        error: Some(format!("Failed to move item: {error}")),
+                    };
+                }
+            }
+        }
+    }
+
+    match fs::rename(&source_abs, &dest_abs) {
+        Ok(()) => TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: true,
+            error: None,
+        },
+        Err(error) => TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: false,
+            error: Some(map_transfer_error("move", &error, &op.source, &op.destination)),
+        },
+    }
+}
+
+/// Copy items under `root` (recursive for directories). Parity intent with TS `copy_items`.
+pub fn copy_items(root: &Path, operations: &[TransferOp]) -> Vec<TransferResult> {
+    operations
+        .iter()
+        .map(|op| copy_single(root, op))
+        .collect()
+}
+
+fn copy_single(root: &Path, op: &TransferOp) -> TransferResult {
+    let source_output = normalize_display_path(&op.source);
+    let dest_output = normalize_display_path(&op.destination);
+
+    let source_abs = match resolve_path(&op.source, root) {
+        Ok(path) => path,
+        Err(error) => {
+            return TransferResult {
+                source: source_output,
+                destination: dest_output,
+                success: false,
+                error: Some(error.message),
+            };
+        }
+    };
+    let dest_abs = match resolve_path(&op.destination, root) {
+        Ok(path) => path,
+        Err(error) => {
+            return TransferResult {
+                source: source_output,
+                destination: dest_output,
+                success: false,
+                error: Some(error.message),
+            };
+        }
+    };
+
+    if paths_equal(&source_abs, root) {
+        return TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: false,
+            error: Some("Copying the project root is not allowed.".into()),
+        };
+    }
+
+    if !source_abs.exists() {
+        return TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: false,
+            error: Some(format!("Source path not found: {}", op.source)),
+        };
+    }
+
+    if let Some(dest_dir) = dest_abs.parent() {
+        if let Err(error) = fs::create_dir_all(dest_dir) {
+            if !dest_dir.is_dir() {
+                return TransferResult {
+                    source: source_output,
+                    destination: dest_output,
+                    success: false,
+                    error: Some(format!("Failed to copy item: {error}")),
+                };
+            }
+        }
+    }
+
+    match copy_recursive(&source_abs, &dest_abs) {
+        Ok(()) => TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: true,
+            error: None,
+        },
+        Err(error) => TransferResult {
+            source: source_output,
+            destination: dest_output,
+            success: false,
+            error: Some(map_transfer_error("copy", &error, &op.source, &op.destination)),
+        },
+    }
+}
+
+/// Recursive copy with overwrite (TS `fs.cp` force + recursive + !errorOnExist).
+fn copy_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let meta = fs::symlink_metadata(src)?;
+    if meta.is_dir() {
+        fs::create_dir_all(dst)?;
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            let dest_child = dst.join(entry.file_name());
+            if file_type.is_dir() {
+                copy_recursive(&entry.path(), &dest_child)?;
+            } else if file_type.is_symlink() {
+                // Follow TS force-copy: materialize symlink target content when possible.
+                let target = fs::read_link(entry.path())?;
+                // Prefer copying pointed-to data if it is a file under the same tree.
+                let resolved = entry.path().parent().unwrap_or(src).join(&target);
+                if resolved.is_dir() {
+                    copy_recursive(&resolved, &dest_child)?;
+                } else if resolved.exists() {
+                    if let Some(parent) = dest_child.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    fs::copy(&resolved, &dest_child)?;
+                } else {
+                    // Fall back to recreating the symlink (best-effort).
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::symlink;
+                        let _ = fs::remove_file(&dest_child);
+                        symlink(&target, &dest_child)?;
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "symlink copy not supported on this platform",
+                        ));
+                    }
+                }
+            } else {
+                if let Some(parent) = dest_child.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::copy(entry.path(), &dest_child)?;
+            }
+        }
+        Ok(())
+    } else {
+        if let Some(parent) = dst.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(src, dst)?;
+        Ok(())
+    }
+}
+
+fn map_transfer_error(
+    verb: &str,
+    error: &std::io::Error,
+    source_relative: &str,
+    destination_relative: &str,
+) -> String {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => format!("Source path not found: {source_relative}"),
+        std::io::ErrorKind::PermissionDenied => {
+            format!(
+                "Permission denied {}ing '{source_relative}' to '{destination_relative}'.",
+                if verb == "move" { "mov" } else { "copy" }
+            )
+        }
+        _ => format!("Failed to {verb} item: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn create_directories_nested_and_idempotent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+
+        let first = create_directories(root, &["a/b/c".into()]);
+        assert!(first[0].success, "{:?}", first[0].error);
+        assert!(root.join("a/b/c").is_dir());
+
+        let second = create_directories(root, &["a/b/c".into()]);
+        assert!(second[0].success, "{:?}", second[0].error);
+        // create_dir_all is idempotent; note is optional when OS returns Ok.
+    }
+
+    #[test]
+    fn create_directories_rejects_file_collision() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        fs::write(root.join("not-a-dir"), "x").expect("write");
+
+        let results = create_directories(root, &["not-a-dir".into()]);
+        assert!(!results[0].success);
+        assert!(
+            results[0]
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("not a directory")
+                || results[0]
+                    .error
+                    .as_deref()
+                    .unwrap_or("")
+                    .contains("Failed to create"),
+            "{:?}",
+            results[0].error
+        );
+    }
+
+    #[test]
+    fn create_directories_rejects_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let results = create_directories(root, &["".into()]);
+        assert!(!results[0].success);
+        assert!(
+            results[0]
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("project root"),
+            "{:?}",
+            results[0].error
+        );
+    }
+
+    #[test]
+    fn create_directories_rejects_traversal() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let results = create_directories(root, &["../outside".into()]);
+        assert!(!results[0].success);
+    }
+
+    #[test]
+    fn move_items_renames_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        fs::create_dir_all(root.join("src")).expect("mkdir");
+        fs::write(root.join("src/a.txt"), "hello").expect("write");
+
+        let results = move_items(
+            root,
+            &[TransferOp {
+                source: "src/a.txt".into(),
+                destination: "dst/b.txt".into(),
+            }],
+        );
+        assert!(results[0].success, "{:?}", results[0].error);
+        assert!(!root.join("src/a.txt").exists());
+        assert_eq!(fs::read_to_string(root.join("dst/b.txt")).unwrap(), "hello");
+    }
+
+    #[test]
+    fn move_items_source_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let results = move_items(
+            root,
+            &[TransferOp {
+                source: "nope.txt".into(),
+                destination: "out.txt".into(),
+            }],
+        );
+        assert!(!results[0].success);
+        assert!(
+            results[0]
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Source path not found"),
+            "{:?}",
+            results[0].error
+        );
+    }
+
+    #[test]
+    fn copy_items_file_and_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        fs::create_dir_all(root.join("tree/nested")).expect("mkdir");
+        fs::write(root.join("tree/nested/leaf.txt"), "leaf").expect("write");
+        fs::write(root.join("solo.txt"), "solo").expect("write");
+
+        let file_copy = copy_items(
+            root,
+            &[TransferOp {
+                source: "solo.txt".into(),
+                destination: "copy-solo.txt".into(),
+            }],
+        );
+        assert!(file_copy[0].success, "{:?}", file_copy[0].error);
+        assert_eq!(
+            fs::read_to_string(root.join("copy-solo.txt")).unwrap(),
+            "solo"
+        );
+        // Original remains (copy, not move).
+        assert!(root.join("solo.txt").exists());
+
+        let dir_copy = copy_items(
+            root,
+            &[TransferOp {
+                source: "tree".into(),
+                destination: "tree-copy".into(),
+            }],
+        );
+        assert!(dir_copy[0].success, "{:?}", dir_copy[0].error);
+        assert_eq!(
+            fs::read_to_string(root.join("tree-copy/nested/leaf.txt")).unwrap(),
+            "leaf"
+        );
+        assert!(root.join("tree/nested/leaf.txt").exists());
+    }
+
+    #[test]
+    fn copy_items_rejects_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let results = copy_items(
+            root,
+            &[TransferOp {
+                source: "".into(),
+                destination: "elsewhere".into(),
+            }],
+        );
+        assert!(!results[0].success);
+        assert!(
+            results[0]
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("project root"),
+            "{:?}",
+            results[0].error
+        );
+    }
+
+    #[test]
+    fn copy_overwrites_existing_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        fs::write(root.join("src.txt"), "new").expect("write");
+        fs::write(root.join("dst.txt"), "old").expect("write");
+        let results = copy_items(
+            root,
+            &[TransferOp {
+                source: "src.txt".into(),
+                destination: "dst.txt".into(),
+            }],
+        );
+        assert!(results[0].success, "{:?}", results[0].error);
+        assert_eq!(fs::read_to_string(root.join("dst.txt")).unwrap(), "new");
+    }
+}

--- a/crates/filesystem-core/src/mutations.rs
+++ b/crates/filesystem-core/src/mutations.rs
@@ -596,4 +596,143 @@ mod tests {
         assert!(results[0].success, "{:?}", results[0].error);
         assert_eq!(fs::read_to_string(root.join("dst.txt")).unwrap(), "new");
     }
+
+    /// Pure residual (BW4): bind `mutations_golden.json` via include_str!.
+    /// Fixture-driven create/move/copy under temp root. NO CLI wire / route flip.
+    #[test]
+    fn mutations_golden_fixture_cases() {
+        #[derive(Debug, serde::Deserialize)]
+        struct MutationsGoldenFixture {
+            cases: Vec<MutationGoldenCase>,
+        }
+
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct MutationGoldenCase {
+            id: String,
+            op: String,
+            #[serde(default)]
+            paths: Vec<String>,
+            #[serde(default)]
+            seed_files: std::collections::HashMap<String, String>,
+            #[serde(default)]
+            operations: Vec<GoldenTransferOp>,
+            #[serde(default)]
+            expect_success: Vec<bool>,
+            #[serde(default)]
+            expect_exists_dirs: Vec<String>,
+            #[serde(default)]
+            expect_exists_files: std::collections::HashMap<String, String>,
+            #[serde(default)]
+            expect_missing: Vec<String>,
+            #[serde(default)]
+            error_contains: Vec<String>,
+        }
+
+        #[derive(Debug, serde::Deserialize)]
+        struct GoldenTransferOp {
+            source: String,
+            destination: String,
+        }
+
+        let raw = include_str!("../fixtures/mutations_golden.json");
+        let fixture: MutationsGoldenFixture =
+            serde_json::from_str(raw).expect("parse mutations_golden.json");
+        assert_eq!(fixture.cases.len(), 5, "expected 5 golden cases");
+
+        for case in fixture.cases {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let root = temp.path();
+            for (rel, content) in &case.seed_files {
+                let path = root.join(rel);
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).expect("seed parent");
+                }
+                fs::write(&path, content).expect("seed file");
+            }
+
+            match case.op.as_str() {
+                "create_directories" => {
+                    let results = create_directories(root, &case.paths);
+                    assert_eq!(
+                        results.len(),
+                        case.expect_success.len(),
+                        "case {} result count",
+                        case.id
+                    );
+                    for (i, (result, expect_ok)) in
+                        results.iter().zip(case.expect_success.iter()).enumerate()
+                    {
+                        assert_eq!(
+                            result.success, *expect_ok,
+                            "case {}[{}] success={:?} err={:?}",
+                            case.id, i, result.success, result.error
+                        );
+                        if !case.error_contains.is_empty() && !*expect_ok {
+                            let err = result.error.as_deref().unwrap_or("");
+                            assert!(
+                                case.error_contains.iter().any(|n| err.contains(n)),
+                                "case {} error {err:?} missing any of {:?}",
+                                case.id,
+                                case.error_contains
+                            );
+                        }
+                    }
+                    for dir in &case.expect_exists_dirs {
+                        assert!(
+                            root.join(dir).is_dir(),
+                            "case {} expected dir {}",
+                            case.id,
+                            dir
+                        );
+                    }
+                }
+                "move_items" | "copy_items" => {
+                    let ops: Vec<TransferOp> = case
+                        .operations
+                        .iter()
+                        .map(|op| TransferOp {
+                            source: op.source.clone(),
+                            destination: op.destination.clone(),
+                        })
+                        .collect();
+                    let results = if case.op == "move_items" {
+                        move_items(root, &ops)
+                    } else {
+                        copy_items(root, &ops)
+                    };
+                    assert_eq!(
+                        results.len(),
+                        case.expect_success.len(),
+                        "case {} result count",
+                        case.id
+                    );
+                    for (i, (result, expect_ok)) in
+                        results.iter().zip(case.expect_success.iter()).enumerate()
+                    {
+                        assert_eq!(
+                            result.success, *expect_ok,
+                            "case {}[{}] success={:?} err={:?}",
+                            case.id, i, result.success, result.error
+                        );
+                    }
+                    for (rel, content) in &case.expect_exists_files {
+                        let got = fs::read_to_string(root.join(rel))
+                            .unwrap_or_else(|e| panic!("case {} read {}: {e}", case.id, rel));
+                        assert_eq!(&got, content, "case {} file {}", case.id, rel);
+                    }
+                    for rel in &case.expect_missing {
+                        assert!(
+                            !root.join(rel).exists(),
+                            "case {} expected missing {}",
+                            case.id,
+                            rel
+                        );
+                    }
+                }
+                other => panic!("case {} unknown op {other}", case.id),
+            }
+        }
+    }
+
 }

--- a/crates/filesystem-core/src/replace_content.rs
+++ b/crates/filesystem-core/src/replace_content.rs
@@ -344,4 +344,33 @@ mod tests {
         assert!(create_search_regex(&bad).is_none());
     }
 
+
+    #[test]
+    fn bw7_create_search_regex_and_ignore_case() {
+        let lit = op("a+b", "x");
+        let re = create_search_regex(&lit).expect("lit");
+        assert!(re.is_match("a+b"));
+        assert!(!re.is_match("aab"));
+        let ci = ReplaceOperation {
+            search: "Foo".into(),
+            replace: "bar".into(),
+            use_regex: false,
+            ignore_case: true,
+        };
+        let re = create_search_regex(&ci).expect("ci");
+        assert!(re.is_match("foo"));
+        assert!(re.is_match("FOO"));
+        let bad = ReplaceOperation {
+            search: "[unterminated".into(),
+            replace: "x".into(),
+            use_regex: true,
+            ignore_case: false,
+        };
+        assert!(create_search_regex(&bad).is_none());
+        assert!(!needs_multiline(&op("plain", "x")));
+        assert!(needs_multiline(&op_regex("^line", "x")));
+        assert!(needs_multiline(&op_regex("end$", "x")));
+        assert!(!needs_multiline(&op_regex("no-anchors", "x")));
+    }
+
 }

--- a/crates/filesystem-core/src/replace_content.rs
+++ b/crates/filesystem-core/src/replace_content.rs
@@ -262,4 +262,50 @@ mod tests {
             "a+b"
         );
     }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ReplaceContentGoldenFixture {
+        cases: Vec<ReplaceContentGoldenCase>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ReplaceContentGoldenCase {
+        id: String,
+        original: String,
+        operations: Vec<ReplaceOperation>,
+        #[serde(rename = "expectModified")]
+        expect_modified: bool,
+        #[serde(rename = "expectReplacements")]
+        expect_replacements: usize,
+        #[serde(rename = "expectNewContent")]
+        expect_new_content: String,
+    }
+
+    /// Pure residual (BW3): bind `replace_content_golden.json` via include_str!.
+    /// No CLI wire / route flip / authority (rej-010).
+    #[test]
+    fn replace_content_golden_fixture_cases() {
+        let raw = include_str!("../fixtures/replace_content_golden.json");
+        let fixture: ReplaceContentGoldenFixture =
+            serde_json::from_str(raw).expect("parse replace_content_golden.json");
+        assert!(!fixture.cases.is_empty());
+        for case in fixture.cases {
+            let result = apply_operations_to_content(&case.original, &case.operations);
+            assert_eq!(
+                result.modified, case.expect_modified,
+                "case {} modified",
+                case.id
+            );
+            assert_eq!(
+                result.replacements_made, case.expect_replacements,
+                "case {} replacements",
+                case.id
+            );
+            assert_eq!(
+                result.new_content, case.expect_new_content,
+                "case {} content",
+                case.id
+            );
+        }
+    }
 }

--- a/crates/filesystem-core/src/replace_content.rs
+++ b/crates/filesystem-core/src/replace_content.rs
@@ -308,4 +308,40 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn build_search_pattern_and_needs_multiline_pure() {
+        let lit = ReplaceOperation {
+            search: "a.b".into(),
+            replace: "x".into(),
+            use_regex: false,
+            ignore_case: false,
+        };
+        assert_eq!(build_search_pattern(&lit), "a\\.b");
+        assert!(!needs_multiline(&lit));
+        let re = ReplaceOperation {
+            search: "^foo$".into(),
+            replace: "bar".into(),
+            use_regex: true,
+            ignore_case: true,
+        };
+        assert_eq!(build_search_pattern(&re), "^foo$");
+        assert!(needs_multiline(&re));
+        let re2 = ReplaceOperation {
+            search: "plain".into(),
+            replace: "x".into(),
+            use_regex: true,
+            ignore_case: false,
+        };
+        assert!(!needs_multiline(&re2));
+        assert!(create_search_regex(&lit).is_some());
+        let bad = ReplaceOperation {
+            search: "[invalid".into(),
+            replace: "x".into(),
+            use_regex: true,
+            ignore_case: false,
+        };
+        assert!(create_search_regex(&bad).is_none());
+    }
+
 }

--- a/crates/filesystem-core/src/replace_content.rs
+++ b/crates/filesystem-core/src/replace_content.rs
@@ -373,4 +373,33 @@ mod tests {
         assert!(!needs_multiline(&op_regex("no-anchors", "x")));
     }
 
+
+    #[test]
+    fn bw8_build_search_pattern_escape_vs_regex() {
+        assert_eq!(build_search_pattern(&op("a+b", "x")), "a\\+b");
+        assert_eq!(build_search_pattern(&op_regex("a+b", "x")), "a+b");
+        let multi = apply_operations_to_content("Aa Aa", &[op_ci("aa", "BB")]);
+        assert!(multi.modified);
+        assert_eq!(multi.replacements_made, 2);
+        assert_eq!(multi.new_content, "BB BB");
+        let bad = ReplaceOperation {
+            search: "(unclosed".into(),
+            replace: "x".into(),
+            use_regex: true,
+            ignore_case: false,
+        };
+        let r = apply_operations_to_content("hello", &[bad]);
+        assert!(!r.modified);
+        assert_eq!(r.replacements_made, 0);
+        assert_eq!(r.new_content, "hello");
+    }
+
+    #[test]
+    fn bw8_needs_multiline_only_regex_anchors() {
+        assert!(!needs_multiline(&op("^x", "y")));
+        assert!(needs_multiline(&op_regex("^x", "y")));
+        assert!(needs_multiline(&op_regex("x$", "y")));
+        assert!(needs_multiline(&op_regex("^x$", "y")));
+        assert!(!needs_multiline(&op_regex("x", "y")));
+    }
 }

--- a/crates/filesystem-core/src/replace_content.rs
+++ b/crates/filesystem-core/src/replace_content.rs
@@ -1,0 +1,265 @@
+//! Pure replace-content engine (TS `src/handlers/replace-content.ts` helpers).
+//!
+//! Offline BW2 pure residual deepen: in-memory search/replace transform only (no I/O).
+//! Tool routing remains LegacyOptIn until CLI wire + differential_green (rej-010).
+//! No authority_rust / ts_deleted claims.
+//!
+//! Regex construction mirrors TS `createSearchRegex` + `applyReplaceOperation`:
+//! - always global within a file
+//! - optional ignore_case
+//! - multiline only when `use_regex` and pattern contains `^` or `$`
+//! - invalid regex → zero replacements (silent no-op)
+
+use regex::RegexBuilder;
+use serde::{Deserialize, Serialize};
+
+use crate::escape_regex;
+
+pub const REPLACE_CONTENT_ROUTE: &str = "rust-replace-content";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ReplaceOperation {
+    pub search: String,
+    pub replace: String,
+    #[serde(default)]
+    pub use_regex: bool,
+    #[serde(default)]
+    pub ignore_case: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyReplaceResult {
+    pub new_content: String,
+    pub replacements_made: usize,
+    /// True when `new_content != original` (after all ops).
+    pub modified: bool,
+}
+
+/// Build the search pattern string (escaped when not regex) — parity with TS.
+pub fn build_search_pattern(op: &ReplaceOperation) -> String {
+    if op.use_regex {
+        op.search.clone()
+    } else {
+        escape_regex(&op.search)
+    }
+}
+
+/// Whether multiline mode should be enabled — parity with TS createSearchRegex.
+pub fn needs_multiline(op: &ReplaceOperation) -> bool {
+    op.use_regex && (op.search.contains('^') || op.search.contains('$'))
+}
+
+/// Compile a global search regex for one operation.
+/// Returns `None` for invalid patterns (TS returns undefined → 0 replacements).
+pub fn create_search_regex(op: &ReplaceOperation) -> Option<regex::Regex> {
+    let pattern = build_search_pattern(op);
+    RegexBuilder::new(&pattern)
+        .case_insensitive(op.ignore_case)
+        .multi_line(needs_multiline(op))
+        .build()
+        .ok()
+}
+
+/// Apply a single replace operation to content — parity with TS `applyReplaceOperation`.
+pub fn apply_replace_operation(
+    current_content: &str,
+    op: &ReplaceOperation,
+) -> ApplyReplaceResult {
+    let Some(search_regex) = create_search_regex(op) else {
+        return ApplyReplaceResult {
+            new_content: current_content.to_string(),
+            replacements_made: 0,
+            modified: false,
+        };
+    };
+
+    let replacements_made = search_regex.find_iter(current_content).count();
+    if replacements_made == 0 {
+        return ApplyReplaceResult {
+            new_content: current_content.to_string(),
+            replacements_made: 0,
+            modified: false,
+        };
+    }
+
+    let new_content = search_regex
+        .replace_all(current_content, op.replace.as_str())
+        .into_owned();
+    let modified = new_content != current_content;
+
+    // TS only counts when replacements were made; still report find_iter count.
+    ApplyReplaceResult {
+        new_content,
+        replacements_made,
+        modified,
+    }
+}
+
+/// Apply ordered operations to in-memory content — pure SSOT for replace_content body.
+///
+/// Parity with TS loop in `processSingleFileReplacement`:
+/// - accumulate replacement counts across ops
+/// - only advance content when replacementsMade > 0 && newContent !== fileContent
+pub fn apply_operations_to_content(
+    original_content: &str,
+    operations: &[ReplaceOperation],
+) -> ApplyReplaceResult {
+    let mut file_content = original_content.to_string();
+    let mut total_replacements = 0usize;
+
+    for op in operations {
+        let step = apply_replace_operation(&file_content, op);
+        if step.replacements_made > 0 && step.new_content != file_content {
+            file_content = step.new_content;
+            total_replacements += step.replacements_made;
+        }
+    }
+
+    ApplyReplaceResult {
+        modified: file_content != original_content,
+        new_content: file_content,
+        replacements_made: total_replacements,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn op(search: &str, replace: &str) -> ReplaceOperation {
+        ReplaceOperation {
+            search: search.into(),
+            replace: replace.into(),
+            use_regex: false,
+            ignore_case: false,
+        }
+    }
+
+    fn op_regex(search: &str, replace: &str) -> ReplaceOperation {
+        ReplaceOperation {
+            search: search.into(),
+            replace: replace.into(),
+            use_regex: true,
+            ignore_case: false,
+        }
+    }
+
+    fn op_ci(search: &str, replace: &str) -> ReplaceOperation {
+        ReplaceOperation {
+            search: search.into(),
+            replace: replace.into(),
+            use_regex: false,
+            ignore_case: true,
+        }
+    }
+
+    #[test]
+    fn simple_literal_replace_counts_all_matches() {
+        let result = apply_operations_to_content(
+            "Hello world, world!",
+            &[op("world", "planet")],
+        );
+        assert!(result.modified);
+        assert_eq!(result.replacements_made, 2);
+        assert_eq!(result.new_content, "Hello planet, planet!");
+    }
+
+    #[test]
+    fn sequential_operations_accumulate_counts() {
+        // 2 from world→galaxy + 2 from galaxy→universe = 4
+        let result = apply_operations_to_content(
+            "Hello world, world!",
+            &[op("world", "galaxy"), op("galaxy", "universe")],
+        );
+        assert!(result.modified);
+        assert_eq!(result.replacements_made, 4);
+        assert_eq!(result.new_content, "Hello universe, universe!");
+    }
+
+    #[test]
+    fn regex_with_capture_groups() {
+        let original = "Error: world not found.\nWarning: world might be deprecated.";
+        let result = apply_operations_to_content(
+            original,
+            &[op_regex("^(Error|Warning):", "Log[$1]:")],
+        );
+        assert!(result.modified);
+        assert_eq!(result.replacements_made, 2);
+        assert_eq!(
+            result.new_content,
+            "Log[Error]: world not found.\nLog[Warning]: world might be deprecated."
+        );
+    }
+
+    #[test]
+    fn case_insensitive_literal() {
+        let result =
+            apply_operations_to_content("Hello world, world!", &[op_ci("hello", "Greetings")]);
+        assert!(result.modified);
+        assert_eq!(result.replacements_made, 1);
+        assert_eq!(result.new_content, "Greetings world, world!");
+    }
+
+    #[test]
+    fn no_match_is_unmodified() {
+        let original = "Nothing to see here.";
+        let result = apply_operations_to_content(original, &[op("world", "planet")]);
+        assert!(!result.modified);
+        assert_eq!(result.replacements_made, 0);
+        assert_eq!(result.new_content, original);
+    }
+
+    #[test]
+    fn empty_content_no_match() {
+        let result = apply_operations_to_content("", &[op("anything", "something")]);
+        assert!(!result.modified);
+        assert_eq!(result.replacements_made, 0);
+        assert_eq!(result.new_content, "");
+    }
+
+    #[test]
+    fn invalid_regex_is_silent_noop() {
+        let original = "abc";
+        let result = apply_operations_to_content(
+            original,
+            &[op_regex("[unterminated", "x")],
+        );
+        assert!(!result.modified);
+        assert_eq!(result.replacements_made, 0);
+        assert_eq!(result.new_content, original);
+    }
+
+    #[test]
+    fn literal_escapes_regex_metacharacters() {
+        let result =
+            apply_operations_to_content("price is $5.00+", &[op("$5.00+", "€5")]);
+        assert!(result.modified);
+        assert_eq!(result.replacements_made, 1);
+        assert_eq!(result.new_content, "price is €5");
+    }
+
+    #[test]
+    fn multiline_anchor_only_when_use_regex() {
+        // use_regex + ^ should match line starts under multi_line
+        let original = "foo\nbar\nfoo";
+        let result =
+            apply_operations_to_content(original, &[op_regex("^foo", "baz")]);
+        assert!(result.modified);
+        assert_eq!(result.replacements_made, 2);
+        assert_eq!(result.new_content, "baz\nbar\nbaz");
+    }
+
+    #[test]
+    fn build_search_pattern_escapes_when_not_regex() {
+        assert_eq!(
+            build_search_pattern(&op("a+b", "x")),
+            r"a\+b"
+        );
+        assert_eq!(
+            build_search_pattern(&op_regex("a+b", "x")),
+            "a+b"
+        );
+    }
+}

--- a/crates/filesystem-core/src/search.rs
+++ b/crates/filesystem-core/src/search.rs
@@ -238,4 +238,24 @@ mod tests {
         assert!(!matches_file_pattern("exact", "other"));
     }
 
+
+    #[test]
+    fn bw7_compile_search_regex_flags_and_file_pattern_edges() {
+        let re = compile_search_regex("/foo/i").expect("i");
+        assert!(re.is_match("FOO"));
+        let re = compile_search_regex("/foo.bar/s").expect("s");
+        // with s flag, . matches newline
+        assert!(re.is_match("foo\nbar"));
+        assert!(matches_file_pattern("README.md", "*md"));
+        assert!(!matches_file_pattern("README.txt", "*md"));
+        assert!(should_skip_dir("a/.git/b"));
+        assert!(should_skip_dir("node_modules"));
+        assert!(!should_skip_dir("src"));
+        let (body, flags) = parse_regex_literal("/x/g");
+        assert_eq!(body, "x");
+        assert_eq!(flags, "g");
+        assert!(matches_file_pattern("app.test.ts", "*.ts"));
+        assert!(!matches_file_pattern("app.test.ts", "*.js"));
+    }
+
 }

--- a/crates/filesystem-core/src/search.rs
+++ b/crates/filesystem-core/src/search.rs
@@ -200,4 +200,22 @@ mod tests {
         let err = search_files(temp.path(), ".", "[invalid", "*", None, None).unwrap_err();
         assert!(err.starts_with("INVALID_REGEX"));
     }
+
+
+    #[test]
+    fn compile_search_regex_supports_literal_flags_and_file_patterns() {
+        let re = compile_search_regex("/foo/i").expect("slash flags");
+        assert!(re.is_match("FOO"));
+        let re = compile_search_regex("bar").expect("plain");
+        assert!(re.is_match("bar"));
+        assert!(!re.is_match("BAR"));
+        assert!(matches_file_pattern("auth.ts", "*.ts"));
+        assert!(matches_file_pattern("readme.md", "*"));
+        assert!(matches_file_pattern("app.config.js", "*.js"));
+        assert!(!matches_file_pattern("auth.ts", "*.js"));
+        assert!(matches_file_pattern("exact.txt", "exact.txt"));
+        assert!(should_skip_dir("src/node_modules/pkg"));
+        assert!(should_skip_dir("target/debug"));
+        assert!(!should_skip_dir("src/lib"));
+    }
 }

--- a/crates/filesystem-core/src/search.rs
+++ b/crates/filesystem-core/src/search.rs
@@ -218,4 +218,24 @@ mod tests {
         assert!(should_skip_dir("target/debug"));
         assert!(!should_skip_dir("src/lib"));
     }
+
+    #[test]
+    fn parse_regex_literal_and_suffix_file_patterns() {
+        let (body, flags) = parse_regex_literal("/ab+c/im");
+        assert_eq!(body, "ab+c");
+        assert_eq!(flags, "im");
+        let (body, flags) = parse_regex_literal("no-slash");
+        assert_eq!(body, "no-slash");
+        assert_eq!(flags, "");
+        // incomplete slash form treated as plain
+        let (body, flags) = parse_regex_literal("/only-open");
+        assert_eq!(body, "/only-open");
+        assert_eq!(flags, "");
+        assert!(matches_file_pattern("readme.md", "*md"));
+        assert!(matches_file_pattern("app.test.ts", "*.ts"));
+        assert!(!matches_file_pattern("app.test.ts", "*.js"));
+        assert!(matches_file_pattern("exact", "exact"));
+        assert!(!matches_file_pattern("exact", "other"));
+    }
+
 }

--- a/crates/filesystem-core/src/search.rs
+++ b/crates/filesystem-core/src/search.rs
@@ -258,4 +258,20 @@ mod tests {
         assert!(!matches_file_pattern("app.test.ts", "*.js"));
     }
 
+
+    #[test]
+    fn bw8_compile_search_regex_m_flag_and_invalid() {
+        let re = compile_search_regex("/^foo$/m").expect("m");
+        assert!(re.is_match("foo"));
+        assert!(re.is_match("x\nfoo\ny"));
+        let err = compile_search_regex("/[unterminated/").unwrap_err();
+        assert!(err.contains("INVALID_REGEX") || err.contains("regex"), "{err}");
+        let (body, flags) = parse_regex_literal("//i");
+        assert_eq!(body, "");
+        assert_eq!(flags, "i");
+        assert!(matches_file_pattern("file", "*") || matches_file_pattern("file", "file"));
+        assert!(!should_skip_dir("src/lib"));
+        assert!(should_skip_dir("a/dist/b"));
+        assert!(should_skip_dir("target"));
+    }
 }

--- a/crates/filesystem-core/src/walk.rs
+++ b/crates/filesystem-core/src/walk.rs
@@ -341,4 +341,20 @@ mod tests {
         assert_eq!(display_path(r"src\a", false), "src/a");
     }
 
+
+
+    #[test]
+    fn bw7_format_timestamp_utc_time_of_day_and_millis() {
+        let secs = 12 * 3600 + 34 * 60 + 56;
+        assert_eq!(format_timestamp_utc(secs, 789), "1970-01-01T12:34:56.789Z");
+        assert!(!is_leap_year(2100));
+        assert!(is_leap_year(2000));
+        assert_eq!(display_path("a/b/", true), "a/b/");
+        assert_eq!(display_path(r"a\b", false), "a/b");
+        assert_eq!(display_path(r"a\b", true), "a/b/");
+        assert!(!should_skip_rel("my_node_modules_backup/x"));
+        assert!(should_skip_rel("a/node_modules/b"));
+        assert!(should_skip_rel(".git"));
+        assert!(should_skip_rel("dist"));
+    }
 }

--- a/crates/filesystem-core/src/walk.rs
+++ b/crates/filesystem-core/src/walk.rs
@@ -357,4 +357,28 @@ mod tests {
         assert!(should_skip_rel(".git"));
         assert!(should_skip_rel("dist"));
     }
+
+
+    #[test]
+    fn bw8_format_timestamp_utc_month_rollover_and_leap() {
+        assert_eq!(format_timestamp_utc(30 * 86_400, 1), "1970-01-31T00:00:00.001Z");
+        assert_eq!(format_timestamp_utc(31 * 86_400, 0), "1970-02-01T00:00:00.000Z");
+        let days = 365 + 365 + 31 + 28;
+        assert_eq!(format_timestamp_utc(days * 86_400, 0), "1972-02-29T00:00:00.000Z");
+        assert!(is_leap_year(1972));
+        assert!(!is_leap_year(1970));
+        assert!(!is_leap_year(2100));
+        assert!(is_leap_year(2400));
+    }
+
+    #[test]
+    fn bw8_should_skip_and_display_path_edges() {
+        assert!(should_skip_rel("foo/target/bar"));
+        assert!(should_skip_rel("dist"));
+        assert!(!should_skip_rel("distribute/x"));
+        assert!(!should_skip_rel("mytarget/x"));
+        assert_eq!(display_path("", true), "/");
+        assert_eq!(display_path("", false), "");
+        assert_eq!(display_path(r"C:\a\b", true), "C:/a/b/");
+    }
 }

--- a/crates/filesystem-core/src/walk.rs
+++ b/crates/filesystem-core/src/walk.rs
@@ -311,4 +311,34 @@ mod tests {
         assert_eq!(result.entries[0].path, "solo.txt");
         assert!(result.entries[0].stats.as_ref().expect("stats").is_file);
     }
+
+    #[test]
+    fn format_timestamp_utc_epoch_and_leap_day() {
+        assert_eq!(format_timestamp_utc(0, 0), "1970-01-01T00:00:00.000Z");
+        assert_eq!(format_timestamp_utc(1, 1), "1970-01-01T00:00:01.001Z");
+        // 2000-03-01 00:00:00 UTC = 951868800
+        assert_eq!(format_timestamp_utc(951_868_800, 0), "2000-03-01T00:00:00.000Z");
+        // leap day 2000-02-29
+        assert_eq!(format_timestamp_utc(951_782_400, 0), "2000-02-29T00:00:00.000Z");
+        assert!(is_leap_year(2000));
+        assert!(is_leap_year(2004));
+        assert!(!is_leap_year(1900));
+        assert!(!is_leap_year(2001));
+        assert!(is_leap_year(2400));
+    }
+
+    #[test]
+    fn should_skip_rel_and_display_path_pure() {
+        assert!(should_skip_rel("node_modules/x"));
+        assert!(should_skip_rel("src/.git/config"));
+        assert!(should_skip_rel("pkg/dist/out"));
+        assert!(should_skip_rel("a/target/b"));
+        assert!(!should_skip_rel("src/lib"));
+        assert!(!should_skip_rel(""));
+        assert_eq!(display_path("src/a", false), "src/a");
+        assert_eq!(display_path("src/a", true), "src/a/");
+        assert_eq!(display_path("src/a/", true), "src/a/");
+        assert_eq!(display_path(r"src\a", false), "src/a");
+    }
+
 }

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -281,9 +281,27 @@
 			"domain": "mcp-tools",
 			"weight": 3,
 			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: pure mutations core on disk \u2014 promotion_hold until CLI wire + allow-list differential_green + prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-13T00:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "cargo test -p filesystem-core mutations; crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs (create_directories residual)",
+				"dependencyGlobs": [
+					"src/handlers/create-directories.ts",
+					"crates/filesystem-core/src/mutations.rs",
+					"crates/filesystem-core/fixtures/mutations_golden.json"
+				],
+				"note": "BW2 offline pure deepen: create_directories in filesystem-core mutations.rs + unit tests; route still LegacyOptIn; NO differential_green"
+			},
 			"tsSurface": "src/handlers/create-directories.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+			"rustSurface": "crates/filesystem-core/src/mutations.rs#create_directories (I/O under resolve_path; CLI/route residual)",
+			"parityTest": "cargo test -p filesystem-core mutations; crates/filesystem-core/fixtures/mutations_golden.json; __tests__/engine/shippedPath.matrix.test.ts",
+			"branch": "offline/mega-bulk-bw2-filesystem-mcp",
+			"notes": "BW2 pure residual: create_directories ported under root policy. Tool route remains LegacyOptIn (tool_routes.rs). authority_rust/ts_deleted NOT claimed. Next: CLI invoke + tip differential."
 		},
 		{
 			"id": "tool/chmod_items",
@@ -348,18 +366,54 @@
 			"domain": "mcp-tools",
 			"weight": 3,
 			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: pure mutations core on disk \u2014 promotion_hold until CLI wire + allow-list differential_green + prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-13T00:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "cargo test -p filesystem-core mutations; crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs (move_items residual)",
+				"dependencyGlobs": [
+					"src/handlers/move-items.ts",
+					"crates/filesystem-core/src/mutations.rs",
+					"crates/filesystem-core/fixtures/mutations_golden.json"
+				],
+				"note": "BW2 offline pure deepen: move_items in filesystem-core mutations.rs + unit tests; route still LegacyOptIn; NO differential_green"
+			},
 			"tsSurface": "src/handlers/move-items.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+			"rustSurface": "crates/filesystem-core/src/mutations.rs#move_items (I/O under resolve_path; CLI/route residual)",
+			"parityTest": "cargo test -p filesystem-core mutations; crates/filesystem-core/fixtures/mutations_golden.json; __tests__/engine/shippedPath.matrix.test.ts",
+			"branch": "offline/mega-bulk-bw2-filesystem-mcp",
+			"notes": "BW2 pure residual: move_items ported under root policy. Tool route remains LegacyOptIn. authority_rust/ts_deleted NOT claimed."
 		},
 		{
 			"id": "tool/copy_items",
 			"domain": "mcp-tools",
 			"weight": 3,
 			"state": "rust_impl",
+			"promotionHold": {
+				"active": true,
+				"reason": "rej-010: pure mutations core on disk \u2014 promotion_hold until CLI wire + allow-list differential_green + prod_audit_pass",
+				"rejectionRef": "rej-010",
+				"since": "2026-07-13T00:00:00+00:00"
+			},
+			"proof": {
+				"status": "missing",
+				"harness": "cargo test -p filesystem-core mutations; crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs (copy_items residual)",
+				"dependencyGlobs": [
+					"src/handlers/copy-items.ts",
+					"crates/filesystem-core/src/mutations.rs",
+					"crates/filesystem-core/fixtures/mutations_golden.json"
+				],
+				"note": "BW2 offline pure deepen: copy_items (recursive) in filesystem-core mutations.rs + unit tests; route still LegacyOptIn; NO differential_green"
+			},
 			"tsSurface": "src/handlers/copy-items.ts",
-			"rustSurface": "crates/filesystem-core/src/mutations.rs \u2192 crates/filesystem-cli",
-			"parityTest": "__tests__/engine/shippedPath.matrix.test.ts"
+			"rustSurface": "crates/filesystem-core/src/mutations.rs#copy_items (I/O under resolve_path; CLI/route residual)",
+			"parityTest": "cargo test -p filesystem-core mutations; crates/filesystem-core/fixtures/mutations_golden.json; __tests__/engine/shippedPath.matrix.test.ts",
+			"branch": "offline/mega-bulk-bw2-filesystem-mcp",
+			"notes": "BW2 pure residual: copy_items recursive port under root policy. Tool route remains LegacyOptIn. authority_rust/ts_deleted NOT claimed."
 		},
 		{
 			"id": "tool/replace_content",
@@ -469,13 +523,20 @@
 			"notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
 		},
 		"bw2_delta": {
-			"rust_impl_deepened": 1,
-			"slice": "tool/apply_diff pure core",
+			"rust_impl_deepened": 4,
+			"slices": [
+				"tool/apply_diff pure core",
+				"tool/create_directories",
+				"tool/move_items",
+				"tool/copy_items"
+			],
 			"files": [
 				"crates/filesystem-core/src/apply_diff.rs",
-				"crates/filesystem-core/fixtures/apply_diff_golden.json"
+				"crates/filesystem-core/fixtures/apply_diff_golden.json",
+				"crates/filesystem-core/src/mutations.rs",
+				"crates/filesystem-core/fixtures/mutations_golden.json"
 			],
-			"notes": "BW2 offline pure residual: apply_diffs_to_file_content ported; proof_missing; route LegacyOptIn; NO authority/ts_deleted"
+			"notes": "BW2 offline pure residual stack: apply_diff + mutations (create/move/copy) ported; proof_missing; route LegacyOptIn; NO authority/ts_deleted/CLI wire"
 		},
 		"summaryNote": "TICK038 tip differential land: list_files/read_content/delete_items proof.status=differential_green @ f5d9d94138c3; summary.parity_proven honesty-corrected from overclaim 7\u21920 (no rows at parity_proven). NO authority_rust/ts_deleted; promotion_hold active; CI main_durable residual.",
 		"tick016_delta": {

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -397,7 +397,7 @@
 			"state": "rust_impl",
 			"promotionHold": {
 				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"reason": "rej-010: pure apply_diff engine on disk \u2014 promotion_hold until allow-list differential_green + prod_audit_pass",
 				"rejectionRef": "rej-010",
 				"since": "2026-07-10T10:53:32+00:00"
 			},
@@ -406,19 +406,23 @@
 				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
 				"dependencyGlobs": [
 					"src/handlers/apply-diff.ts",
+					"src/utils/apply-diff-utils.ts",
+					"src/utils/string-utils.ts",
+					"crates/filesystem-core/src/apply_diff.rs",
+					"crates/filesystem-core/fixtures/apply_diff_golden.json",
 					"test/fixtures/golden/apply_diff.golden.json",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh",
 					"crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs"
 				],
-				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+				"note": "BW2 offline pure deepen: filesystem-core apply_diff pure engine + unit tests + golden fixture; route still LegacyOptIn (TS) until CLI wire + allow-list expand; NO differential_green"
 			},
-			"tsSurface": "src/handlers/apply-diff.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
-			"rustSurface": "crates/filesystem-core/src/apply_diff.rs \u2192 crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/apply_diff.golden.json; __tests__/engine/applyDiffGoldenParity.test.ts; cargo test -p filesystem-cli --test apply_diff_golden_parity",
+			"tsSurface": "src/handlers/apply-diff.ts; src/utils/apply-diff-utils.ts; src/engine/rust-apply-diff.ts (opt-out via FILESYSTEM_USE_RUST_APPLY_DIFF=ts)",
+			"rustSurface": "crates/filesystem-core/src/apply_diff.rs (pure content transform; I/O residual)",
+			"parityTest": "cargo test -p filesystem-core apply_diff; crates/filesystem-core/fixtures/apply_diff_golden.json; test/fixtures/golden/apply_diff.golden.json",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#apply_diff_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice apply-diff",
-			"branch": "feat/rust-web-mcp-http-transport",
-			"notes": "S2 edit slice: golden MCP parity for apply_diff (edit_file). cycle47 rej-010: apply-diff bounded differential harness (5 cases). rust_impl only \u2014 authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+			"branch": "offline/mega-bulk-bw2-filesystem-mcp",
+			"notes": "BW2 pure residual: apply_diffs_to_file_content + string helpers ported from TS utils. Tool route remains LegacyOptIn (tool_routes.rs). authority_rust/ts_deleted NOT claimed. Next: CLI invoke + fail-closed allow-list expand + tip differential."
 		}
 	],
 	"summary": {
@@ -463,6 +467,15 @@
 			"slice": "chown-items",
 			"verificationRef": "verification/filesystem-mcp-cycle64-chown-items-rust-impl.json",
 			"notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
+		},
+		"bw2_delta": {
+			"rust_impl_deepened": 1,
+			"slice": "tool/apply_diff pure core",
+			"files": [
+				"crates/filesystem-core/src/apply_diff.rs",
+				"crates/filesystem-core/fixtures/apply_diff_golden.json"
+			],
+			"notes": "BW2 offline pure residual: apply_diffs_to_file_content ported; proof_missing; route LegacyOptIn; NO authority/ts_deleted"
 		},
 		"summaryNote": "TICK038 tip differential land: list_files/read_content/delete_items proof.status=differential_green @ f5d9d94138c3; summary.parity_proven honesty-corrected from overclaim 7\u21920 (no rows at parity_proven). NO authority_rust/ts_deleted; promotion_hold active; CI main_durable residual.",
 		"tick016_delta": {

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -422,27 +422,28 @@
 			"state": "rust_impl",
 			"promotionHold": {
 				"active": true,
-				"reason": "rej-010: differential_green at bound SHAs \u2014 promotion_hold until prod_audit_pass",
+				"reason": "rej-010: pure replace_content engine on disk \u2014 promotion_hold until CLI wire + allow-list differential_green + prod_audit_pass",
 				"rejectionRef": "rej-010",
-				"since": "2026-07-10T10:53:32+00:00"
+				"since": "2026-07-13T00:00:00+00:00"
 			},
 			"proof": {
 				"status": "missing",
-				"harness": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
+				"harness": "cargo test -p filesystem-core replace_content; crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content residual",
 				"dependencyGlobs": [
 					"src/handlers/replace-content.ts",
-					"test/fixtures/golden/replace_content.golden.json",
 					"crates/filesystem-core/src/replace_content.rs",
+					"crates/filesystem-core/fixtures/replace_content_golden.json",
 					"scripts/differential/**",
 					"scripts/run-filesystem-mcp-differential.sh"
 				],
-				"note": "tick-016: stale non-main differential_green cleared; tool not in main fail-closed allow-list (list/read/write only)"
+				"note": "BW2 offline pure deepen: filesystem-core replace_content pure engine + unit tests + golden fixture; route still LegacyOptIn (TS) until CLI wire + allow-list expand; NO differential_green"
 			},
 			"tsSurface": "src/handlers/replace-content.ts",
-			"rustSurface": "crates/filesystem-core/src/replace_content.rs \u2192 crates/filesystem-cli",
-			"parityTest": "test/fixtures/golden/replace_content.golden.json; __tests__/handlers/replace-content.success.test.ts",
+			"rustSurface": "crates/filesystem-core/src/replace_content.rs (pure content transform; I/O residual)",
+			"parityTest": "cargo test -p filesystem-core replace_content; crates/filesystem-core/fixtures/replace_content_golden.json; __tests__/handlers/replace-content.success.test.ts",
 			"differentialTest": "crates/filesystem-mcp-server/tests/filesystem_mcp_differential.rs#replace_content_differential_matches_ts_oracle; scripts/run-filesystem-mcp-differential.sh --slice replace-content",
-			"notes": "Cycle62 rej-010: replace_content rust_impl + bounded differential harness (2 golden cases). authority_rust NOT claimed. tick-016: residual \u2014 not in main allow-list."
+			"branch": "offline/mega-bulk-bw2-filesystem-mcp",
+			"notes": "BW2 pure residual: apply_operations_to_content + create_search_regex ported from TS handler helpers. Tool route remains LegacyOptIn (tool_routes.rs). authority_rust/ts_deleted NOT claimed. Next: CLI invoke + fail-closed allow-list expand + tip differential."
 		},
 		{
 			"id": "tool/apply_diff",
@@ -523,20 +524,23 @@
 			"notes": "rej-010 rust_impl ONLY \u2014 cycle64 next ts_only slice: chown-items bounded differential (2 golden cases)"
 		},
 		"bw2_delta": {
-			"rust_impl_deepened": 4,
+			"rust_impl_deepened": 5,
 			"slices": [
 				"tool/apply_diff pure core",
 				"tool/create_directories",
 				"tool/move_items",
-				"tool/copy_items"
+				"tool/copy_items",
+				"tool/replace_content pure core"
 			],
 			"files": [
 				"crates/filesystem-core/src/apply_diff.rs",
 				"crates/filesystem-core/fixtures/apply_diff_golden.json",
 				"crates/filesystem-core/src/mutations.rs",
-				"crates/filesystem-core/fixtures/mutations_golden.json"
+				"crates/filesystem-core/fixtures/mutations_golden.json",
+				"crates/filesystem-core/src/replace_content.rs",
+				"crates/filesystem-core/fixtures/replace_content_golden.json"
 			],
-			"notes": "BW2 offline pure residual stack: apply_diff + mutations (create/move/copy) ported; proof_missing; route LegacyOptIn; NO authority/ts_deleted/CLI wire"
+			"notes": "BW2 offline pure residual stack: apply_diff + mutations (create/move/copy) + replace_content pure core; proof_missing; route LegacyOptIn; NO authority/ts_deleted/CLI wire"
 		},
 		"summaryNote": "TICK038 tip differential land: list_files/read_content/delete_items proof.status=differential_green @ f5d9d94138c3; summary.parity_proven honesty-corrected from overclaim 7\u21920 (no rows at parity_proven). NO authority_rust/ts_deleted; promotion_hold active; CI main_durable residual.",
 		"tick016_delta": {


### PR DESCRIPTION
## Summary
FLEET pure residual deepen for filesystem-mcp (no route flip, no authority_rust claim).

## Scope
- Pure residual ports/tests: walk/diff/replace/search/path + chmod/chown mode_policy edges
- Offline bulk residual branch on live main tip
- Does NOT claim parity_proven / authority_rust / ts_deleted (rej-010/011/013)

## Residual remaining after merge
- Highest-value TS residual: transport/stdio-ts-adapter at src/index.ts:149-150 (StdioServerTransport)
- Next proof-missing near rust_impl: tool/search_files at src/handlers/search-files.ts:234 (shouldUseRustSearchEngine opt-in only) + src/engine/rust-search.ts:68-69
