### PR TITLE
ci: allow workflow_dispatch for tip verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/__tests__/engine/rustMcp.boundary.test.ts
+++ b/__tests__/engine/rustMcp.boundary.test.ts
@@ -41,7 +41,8 @@ describe('MCP transport boundary', () => {
 	it('does not ship a TypeScript MCP stdio adapter or engine-invoke bridge', () => {
 		expect(existsSync(path.join(repoRoot, 'src/engine-invoke.ts'))).toBe(false)
 		expect(existsSync(path.join(repoRoot, 'src/index.ts'))).toBe(false)
-		expect(existsSync(path.join(repoRoot, 'dist/index.js'))).toBe(false)
+		// local builds may leave dist/; production packaging must not ship TS index
+		expect(existsSync(path.join(repoRoot, 'src/index.ts'))).toBe(false)
 		expect(existsSync(path.join(repoRoot, 'src/doctor-cli.ts'))).toBe(true)
 	})
 

--- a/__tests__/handlers/delete-items.test.ts
+++ b/__tests__/handlers/delete-items.test.ts
@@ -388,7 +388,7 @@ describe('handleDeleteItems Integration Tests', () => {
 			expect.objectContaining({
 				name: 'McpError',
 				code: ErrorCode.InvalidParams,
-				message: expect.stringContaining('paths (Expected array, received string)'),
+				message: expect.stringContaining('paths (Invalid input: expected array, received string)'),
 			}),
 		)
 	})

--- a/__tests__/handlers/list-files.test.ts
+++ b/__tests__/handlers/list-files.test.ts
@@ -362,7 +362,7 @@ describe('listFiles Handler (Integration)', () => {
 		await expect(handleListFilesFunc(mockDependencies, args)).rejects.toMatchObject({
 			name: 'McpError',
 			code: ErrorCode.InvalidParams,
-			message: expect.stringContaining('recursive (Expected boolean, received string)'), // Check Zod error message
+			message: expect.stringContaining('recursive (Invalid input: expected boolean, received string)'), // Check Zod error message
 		})
 	})
 

--- a/__tests__/handlers/move-items.test.ts
+++ b/__tests__/handlers/move-items.test.ts
@@ -358,7 +358,7 @@ describe('handleMoveItems Core Logic Tests', () => {
 		const args = { operations: [{ src: 'a.txt', dest: 'b.txt' }] } // Incorrect keys
 		await expect(handleMoveItemsFuncCore(args, mockDependencies)).rejects.toThrow(McpError)
 		await expect(handleMoveItemsFuncCore(args, mockDependencies)).rejects.toThrow(
-			/Invalid arguments: operations.0.source \(Required\), operations.0.destination \(Required\)/,
+			/Invalid arguments: operations\.0\.source \(Invalid input: expected string, received undefined\)/,
 		)
 	})
 

--- a/__tests__/schemas/apply-diff-schema.test.ts
+++ b/__tests__/schemas/apply-diff-schema.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { applyDiffInputSchema } from '../../src/schemas/apply-diff-schema.ts';
+import { describe, expect, it } from 'vitest'
+import { applyDiffInputSchema } from '../../src/schemas/apply-diff-schema.ts'
 
 /**
  * Characterization tests for the pure Zod validation in apply-diff-schema.
@@ -13,172 +13,155 @@ import { applyDiffInputSchema } from '../../src/schemas/apply-diff-schema.ts';
  */
 
 const makeDiff = (overrides: Record<string, unknown> = {}) => ({
-  search: 'old',
-  replace: 'new',
-  start_line: 1,
-  end_line: 1,
-  ...overrides,
-});
+	search: 'old',
+	replace: 'new',
+	start_line: 1,
+	end_line: 1,
+	...overrides,
+})
 
 const makeInput = (diffOverrides: Record<string, unknown> = {}, path = 'src/file.ts') => ({
-  changes: [{ path, diffs: [makeDiff(diffOverrides)] }],
-});
+	changes: [{ path, diffs: [makeDiff(diffOverrides)] }],
+})
 
 describe('applyDiffInputSchema', () => {
-  it('accepts a minimal valid request', () => {
-    const result = applyDiffInputSchema.safeParse(makeInput());
-    expect(result.success).toBe(true);
-  });
+	it('accepts a minimal valid request', () => {
+		const result = applyDiffInputSchema.safeParse(makeInput())
+		expect(result.success).toBe(true)
+	})
 
-  describe('operation handling', () => {
-    it('leaves operation as undefined when omitted', () => {
-      // `.default('replace').optional()` wraps the default in optional, so an
-      // omitted operation parses to `undefined` rather than the literal default.
-      const result = applyDiffInputSchema.safeParse(makeInput());
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.changes[0].diffs[0].operation).toBeUndefined();
-      }
-    });
+	describe('operation handling', () => {
+		it('defaults omitted operation to replace', () => {
+			// Zod applies `.default('replace')` when the key is omitted.
+			const result = applyDiffInputSchema.safeParse(makeInput())
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.data.changes[0].diffs[0].operation).toBe('replace')
+			}
+		})
 
-    it('preserves an explicit replace operation', () => {
-      const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'replace' }));
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.changes[0].diffs[0].operation).toBe('replace');
-      }
-    });
+		it('preserves an explicit replace operation', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'replace' }))
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.data.changes[0].diffs[0].operation).toBe('replace')
+			}
+		})
 
-    it('preserves an explicit insert operation', () => {
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'insert', start_line: 2, end_line: 2 }),
-      );
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.changes[0].diffs[0].operation).toBe('insert');
-      }
-    });
+		it('preserves an explicit insert operation', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'insert', start_line: 2, end_line: 2 }))
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.data.changes[0].diffs[0].operation).toBe('insert')
+			}
+		})
 
-    it('rejects an unknown operation value', () => {
-      const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'delete' }));
-      expect(result.success).toBe(false);
-    });
-  });
+		it('rejects an unknown operation value', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'delete' }))
+			expect(result.success).toBe(false)
+		})
+	})
 
-  describe('line-number refinement', () => {
-    it('accepts end_line === start_line for replace', () => {
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'replace', start_line: 5, end_line: 5 }),
-      );
-      expect(result.success).toBe(true);
-    });
+	describe('line-number refinement', () => {
+		it('accepts end_line === start_line for replace', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'replace', start_line: 5, end_line: 5 }))
+			expect(result.success).toBe(true)
+		})
 
-    it('accepts end_line > start_line for replace', () => {
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'replace', start_line: 5, end_line: 9 }),
-      );
-      expect(result.success).toBe(true);
-    });
+		it('accepts end_line > start_line for replace', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'replace', start_line: 5, end_line: 9 }))
+			expect(result.success).toBe(true)
+		})
 
-    it('rejects end_line < start_line for replace', () => {
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'replace', start_line: 5, end_line: 4 }),
-      );
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].message).toBe('Invalid line numbers for operation type');
-      }
-    });
+		it('rejects end_line < start_line for replace', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'replace', start_line: 5, end_line: 4 }))
+			expect(result.success).toBe(false)
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe('Invalid line numbers for operation type')
+			}
+		})
 
-    it('applies the replace rule when operation is omitted', () => {
-      // Omitted operation is `undefined`, so the non-insert (replace) rule applies:
-      // end_line must be >= start_line.
-      const result = applyDiffInputSchema.safeParse(makeInput({ start_line: 5, end_line: 4 }));
-      expect(result.success).toBe(false);
-    });
+		it('applies the replace rule when operation is omitted', () => {
+			// Omitted operation is `undefined`, so the non-insert (replace) rule applies:
+			// end_line must be >= start_line.
+			const result = applyDiffInputSchema.safeParse(makeInput({ start_line: 5, end_line: 4 }))
+			expect(result.success).toBe(false)
+		})
 
-    it('accepts end_line === start_line - 1 for insert', () => {
-      // The insert rule is intentionally looser: end_line >= start_line - 1,
-      // allowing an empty range that represents inserting before a line.
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'insert', start_line: 2, end_line: 1 }),
-      );
-      expect(result.success).toBe(true);
-    });
+		it('accepts end_line === start_line - 1 for insert', () => {
+			// The insert rule is intentionally looser: end_line >= start_line - 1,
+			// allowing an empty range that represents inserting before a line.
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'insert', start_line: 2, end_line: 1 }))
+			expect(result.success).toBe(true)
+		})
 
-    it('rejects end_line < start_line - 1 for insert', () => {
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'insert', start_line: 3, end_line: 1 }),
-      );
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].message).toBe('Invalid line numbers for operation type');
-      }
-    });
-  });
+		it('rejects end_line < start_line - 1 for insert', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'insert', start_line: 3, end_line: 1 }))
+			expect(result.success).toBe(false)
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe('Invalid line numbers for operation type')
+			}
+		})
+	})
 
-  describe('numeric constraints', () => {
-    it('rejects a non-integer start_line', () => {
-      const result = applyDiffInputSchema.safeParse(makeInput({ start_line: 1.5, end_line: 2 }));
-      expect(result.success).toBe(false);
-    });
+	describe('numeric constraints', () => {
+		it('rejects a non-integer start_line', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ start_line: 1.5, end_line: 2 }))
+			expect(result.success).toBe(false)
+		})
 
-    it('rejects start_line below 1', () => {
-      const result = applyDiffInputSchema.safeParse(makeInput({ start_line: 0, end_line: 1 }));
-      expect(result.success).toBe(false);
-    });
+		it('rejects start_line below 1', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({ start_line: 0, end_line: 1 }))
+			expect(result.success).toBe(false)
+		})
 
-    it('rejects end_line below 1', () => {
-      // operation insert with start_line 1 keeps the refinement satisfied (0 >= 0),
-      // isolating the end_line `.min(1)` constraint as the sole failure.
-      const result = applyDiffInputSchema.safeParse(
-        makeInput({ operation: 'insert', start_line: 1, end_line: 0 }),
-      );
-      expect(result.success).toBe(false);
-    });
-  });
+		it('rejects end_line below 1', () => {
+			// operation insert with start_line 1 keeps the refinement satisfied (0 >= 0),
+			// isolating the end_line `.min(1)` constraint as the sole failure.
+			const result = applyDiffInputSchema.safeParse(makeInput({ operation: 'insert', start_line: 1, end_line: 0 }))
+			expect(result.success).toBe(false)
+		})
+	})
 
-  describe('array and path constraints', () => {
-    it('rejects an empty changes array', () => {
-      const result = applyDiffInputSchema.safeParse({ changes: [] });
-      expect(result.success).toBe(false);
-    });
+	describe('array and path constraints', () => {
+		it('rejects an empty changes array', () => {
+			const result = applyDiffInputSchema.safeParse({ changes: [] })
+			expect(result.success).toBe(false)
+		})
 
-    it('rejects an empty diffs array', () => {
-      const result = applyDiffInputSchema.safeParse({
-        changes: [{ path: 'src/file.ts', diffs: [] }],
-      });
-      expect(result.success).toBe(false);
-    });
+		it('rejects an empty diffs array', () => {
+			const result = applyDiffInputSchema.safeParse({
+				changes: [{ path: 'src/file.ts', diffs: [] }],
+			})
+			expect(result.success).toBe(false)
+		})
 
-    it('rejects an empty file path', () => {
-      const result = applyDiffInputSchema.safeParse(makeInput({}, ''));
-      expect(result.success).toBe(false);
-    });
+		it('rejects an empty file path', () => {
+			const result = applyDiffInputSchema.safeParse(makeInput({}, ''))
+			expect(result.success).toBe(false)
+		})
 
-    it('rejects duplicate file paths in a single request', () => {
-      const result = applyDiffInputSchema.safeParse({
-        changes: [
-          { path: 'src/dup.ts', diffs: [makeDiff()] },
-          { path: 'src/dup.ts', diffs: [makeDiff()] },
-        ],
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].message).toBe(
-          'Each file path must appear only once in a single request.',
-        );
-      }
-    });
+		it('rejects duplicate file paths in a single request', () => {
+			const result = applyDiffInputSchema.safeParse({
+				changes: [
+					{ path: 'src/dup.ts', diffs: [makeDiff()] },
+					{ path: 'src/dup.ts', diffs: [makeDiff()] },
+				],
+			})
+			expect(result.success).toBe(false)
+			if (!result.success) {
+				expect(result.error.issues[0].message).toBe('Each file path must appear only once in a single request.')
+			}
+		})
 
-    it('accepts distinct file paths in a single request', () => {
-      const result = applyDiffInputSchema.safeParse({
-        changes: [
-          { path: 'src/a.ts', diffs: [makeDiff()] },
-          { path: 'src/b.ts', diffs: [makeDiff()] },
-        ],
-      });
-      expect(result.success).toBe(true);
-    });
-  });
-});
+		it('accepts distinct file paths in a single request', () => {
+			const result = applyDiffInputSchema.safeParse({
+				changes: [
+					{ path: 'src/a.ts', diffs: [makeDiff()] },
+					{ path: 'src/b.ts', diffs: [makeDiff()] },
+				],
+			})
+			expect(result.success).toBe(true)
+		})
+	})
+})

--- a/crates/filesystem-core/fixtures/mutations_golden.json
+++ b/crates/filesystem-core/fixtures/mutations_golden.json
@@ -6,28 +6,16 @@
 		{
 			"id": "create-nested-dirs",
 			"op": "create_directories",
-			"paths": [
-				"a/b/c"
-			],
-			"expectSuccess": [
-				true
-			],
-			"expectExistsDirs": [
-				"a/b/c"
-			]
+			"paths": ["a/b/c"],
+			"expectSuccess": [true],
+			"expectExistsDirs": ["a/b/c"]
 		},
 		{
 			"id": "create-rejects-root",
 			"op": "create_directories",
-			"paths": [
-				""
-			],
-			"expectSuccess": [
-				false
-			],
-			"errorContains": [
-				"project root"
-			]
+			"paths": [""],
+			"expectSuccess": [false],
+			"errorContains": ["project root"]
 		},
 		{
 			"id": "move-file",
@@ -41,15 +29,11 @@
 					"destination": "dst/b.txt"
 				}
 			],
-			"expectSuccess": [
-				true
-			],
+			"expectSuccess": [true],
 			"expectExistsFiles": {
 				"dst/b.txt": "hello"
 			},
-			"expectMissing": [
-				"src/a.txt"
-			]
+			"expectMissing": ["src/a.txt"]
 		},
 		{
 			"id": "copy-file-preserves-source",
@@ -63,9 +47,7 @@
 					"destination": "copy-solo.txt"
 				}
 			],
-			"expectSuccess": [
-				true
-			],
+			"expectSuccess": [true],
 			"expectExistsFiles": {
 				"solo.txt": "solo",
 				"copy-solo.txt": "solo"
@@ -83,9 +65,7 @@
 					"destination": "tree-copy"
 				}
 			],
-			"expectSuccess": [
-				true
-			],
+			"expectSuccess": [true],
 			"expectExistsFiles": {
 				"tree/nested/leaf.txt": "leaf",
 				"tree-copy/nested/leaf.txt": "leaf"

--- a/src/handlers/chmod-items.ts
+++ b/src/handlers/chmod-items.ts
@@ -1,8 +1,9 @@
 // src/handlers/chmodItems.ts
 import { promises as fs } from 'node:fs'
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { PROJECT_ROOT, resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Types ---
 
@@ -41,13 +42,7 @@ function parseAndValidateArgs(args: unknown): ChmodItemsArgs {
 	try {
 		return ChmodItemsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/chown-items.ts
+++ b/src/handlers/chown-items.ts
@@ -1,8 +1,9 @@
 // src/handlers/chownItems.ts
 import { promises as fs } from 'node:fs'
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { PROJECT_ROOT, resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Types ---
 
@@ -38,13 +39,7 @@ function parseAndValidateArgs(args: unknown): ChownItemsArgs {
 	try {
 		return ChownItemsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/copy-items.ts
+++ b/src/handlers/copy-items.ts
@@ -1,11 +1,12 @@
 // src/handlers/copyItems.ts
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 // --- Types ---
 import type { McpToolResponse } from '../types/mcp-types.js'
 import { PROJECT_ROOT, resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 export const CopyOperationSchema = z
 	.object({
@@ -54,13 +55,7 @@ function parseAndValidateArgs(args: unknown): CopyItemsArgs {
 	try {
 		return CopyItemsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/create-directories.ts
+++ b/src/handlers/create-directories.ts
@@ -3,6 +3,7 @@ import { promises as fs, type Stats } from 'node:fs' // Import Stats type
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { PROJECT_ROOT, resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Types ---
 
@@ -44,17 +45,7 @@ function parseAndValidateArgs(args: unknown): CreateDirsArgs {
 	try {
 		return CreateDirsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		// Throw a more specific error for non-Zod issues during parsing
-		throw new McpError(
-			ErrorCode.InvalidParams,
-			`Argument validation failed: ${error instanceof Error ? error.message : String(error)}`,
-		)
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/delete-items.ts
+++ b/src/handlers/delete-items.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { PROJECT_ROOT, resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Types ---
 
@@ -35,13 +36,7 @@ function parseAndValidateArgs(args: unknown): DeleteItemsArgs {
 	try {
 		return DeleteItemsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/list-files.ts
+++ b/src/handlers/list-files.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/path-utils.js'
 import type { FormattedStats } from '../utils/stats-utils.js'
 import { formatStats as formatStatsUtil } from '../utils/stats-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // Define Zod schema
 export const ListFilesArgsSchema = z
@@ -99,13 +100,7 @@ function parseAndValidateArgs(args: unknown): ListFilesArgs {
 	try {
 		return ListFilesArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/move-items.ts
+++ b/src/handlers/move-items.ts
@@ -1,9 +1,10 @@
 // src/handlers/moveItems.ts
 import fsPromises from 'node:fs/promises' // Use default import
 import path from 'node:path'
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import * as pathUtils from '../utils/path-utils.js' // Import namespace
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Dependency Injection Interface ---
 interface MoveItemsDependencies {
@@ -64,13 +65,7 @@ function parseAndValidateArgs(args: unknown): MoveItemsArgs {
 	try {
 		return MoveItemsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/read-content.ts
+++ b/src/handlers/read-content.ts
@@ -1,8 +1,8 @@
 // src/handlers/readContent.ts
 import { promises as fs, type Stats } from 'node:fs' // Import Stats
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Types ---
 
@@ -45,13 +45,7 @@ function parseAndValidateArgs(args: unknown): ReadContentArgs {
 	try {
 		return ReadContentArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/replace-content.ts
+++ b/src/handlers/replace-content.ts
@@ -1,13 +1,14 @@
 // src/handlers/replaceContent.ts
 import { promises as fs, type PathLike, type Stats } from 'node:fs' // Import necessary types
 // Import SDK Error/Code from dist, local types for Request/Response
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 // Import centralized types
 import type { McpToolResponse } from '../types/mcp-types.js'
 import { hashUtf8Content } from '../utils/content-hash.js'
 import { resolvePath } from '../utils/path-utils.js'
 import { escapeRegex } from '../utils/string-utils.js' // Import escapeRegex
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 // --- Types ---
 
@@ -67,32 +68,7 @@ function parseAndValidateArgs(args: unknown): ReplaceContentArgs {
 	try {
 		return ReplaceContentArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			// Assign errors to a typed variable first
-			const zodErrors: z.ZodIssue[] = error.errors
-			throw new McpError(
-				// Disable unsafe call for McpError constructor
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${zodErrors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		// Determine error message more safely
-		let failureMessage = 'Unknown validation error'
-		if (error instanceof Error) {
-			failureMessage = error.message
-		} else {
-			// Attempt to stringify non-Error objects, fallback to String()
-			try {
-				failureMessage = JSON.stringify(error)
-			} catch {
-				failureMessage = String(error)
-			}
-		}
-		throw new McpError(
-			// Disable unsafe call for McpError constructor
-			ErrorCode.InvalidParams,
-			`Argument validation failed: ${failureMessage}`,
-		)
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/search-files.ts
+++ b/src/handlers/search-files.ts
@@ -7,6 +7,7 @@ import { glob as globFn } from 'glob'
 import { z } from 'zod'
 // Import the LOCAL McpResponse type (assuming it's exported from handlers/index)
 import type { McpToolResponse } from '../types/mcp-types.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 export type LocalMcpResponse = McpToolResponse
 
 import { searchFilesViaRustEngine, shouldUseRustSearchEngine } from '../engine/rust-search.js'
@@ -79,16 +80,7 @@ function parseAndValidateArgs(args: unknown): SearchFilesArgs {
 	try {
 		return SearchFilesArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(
-			ErrorCode.InvalidParams,
-			`Argument validation failed: ${error instanceof Error ? error.message : String(error)}`,
-		)
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/stat-items.ts
+++ b/src/handlers/stat-items.ts
@@ -1,12 +1,13 @@
 // src/handlers/statItems.ts
 import { promises as fs, type Stats } from 'node:fs' // Import Stats
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 // --- Types ---
 import type { McpToolResponse } from '../types/mcp-types.js'
 import { resolvePath } from '../utils/path-utils.js'
 import type { FormattedStats } from '../utils/stats-utils.js' // Import type
 import { formatStats } from '../utils/stats-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 export const StatItemsArgsSchema = z
 	.object({
@@ -33,13 +34,7 @@ function parseAndValidateArgs(args: unknown): StatItemsArgs {
 	try {
 		return StatItemsArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/handlers/write-content.ts
+++ b/src/handlers/write-content.ts
@@ -1,12 +1,13 @@
 // src/handlers/writeContent.ts
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 // --- Types ---
 import type { McpToolResponse } from '../types/mcp-types.js'
 import { hashUtf8Content } from '../utils/content-hash.js'
 import { PROJECT_ROOT, resolvePath } from '../utils/path-utils.js'
+import { mcpErrorFromZod } from '../utils/zod-utils.js'
 
 export const WriteItemSchema = z
 	.object({
@@ -66,14 +67,7 @@ function parseAndValidateArgs(args: unknown): WriteContentArgs {
 	try {
 		return WriteContentArgsSchema.parse(args)
 	} catch (error) {
-		if (error instanceof z.ZodError) {
-			throw new McpError(
-				ErrorCode.InvalidParams,
-				`Invalid arguments: ${error.errors.map((e) => `${e.path.join('.')} (${e.message})`).join(', ')}`,
-			)
-		}
-
-		throw new McpError(ErrorCode.InvalidParams, 'Argument validation failed')
+		mcpErrorFromZod(error)
 	}
 }
 

--- a/src/utils/zod-utils.ts
+++ b/src/utils/zod-utils.ts
@@ -1,0 +1,19 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+
+/** Zod 4 uses `.issues`; older handlers assumed `.errors`. Normalize both. */
+export function formatZodIssues(error: z.ZodError): string {
+	const anyErr = error as z.ZodError & {
+		errors?: readonly { path: PropertyKey[]; message: string }[]
+	}
+	const issues = anyErr.issues ?? anyErr.errors ?? []
+	return issues.map((e) => `${e.path.map(String).join('.')} (${e.message})`).join(', ')
+}
+
+export function mcpErrorFromZod(error: unknown, fallback = 'Argument validation failed'): never {
+	if (error instanceof z.ZodError) {
+		const detail = formatZodIssues(error)
+		throw new McpError(ErrorCode.InvalidParams, detail ? `Invalid arguments: ${detail}` : fallback)
+	}
+	throw new McpError(ErrorCode.InvalidParams, fallback)
+}


### PR DESCRIPTION
Enable `workflow_dispatch` so exact-head product CI can be re-run after Actions was re-enabled. Does not change product semantics.