### PR TITLE
fix(ci): Darwin native builds on Sylphx self-hosted macOS only

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -39,12 +39,13 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # Both Darwin targets on macos-latest (arm64 host); x86_64 is
-          # cross-compiled. macos-13 (Intel) runners queue for long periods.
-          - host: macos-latest
+          # Product Darwin: Sylphx self-hosted only (no GitHub-hosted macos-*).
+          # QEMU amd64 fleet: x86_64 native; aarch64 cross-compiled on same host.
+          
+          - host: [self-hosted, sylphx, macos, standard]
             target: aarch64-apple-darwin
             platform_key: darwin-arm64
-          - host: macos-latest
+          - host: [self-hosted, sylphx, macos, standard]
             target: x86_64-apple-darwin
             platform_key: darwin-x64
           - host: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # Both Darwin targets on macos-latest; x86_64 is cross-compiled.
-          # macos-13 Intel runners often queue indefinitely.
-          - host: macos-latest
+          # Product Darwin: Sylphx self-hosted only (no GitHub-hosted macos-*).
+          # QEMU amd64 fleet: x86_64 native; aarch64 cross-compiled on same host.
+          
+          - host: [self-hosted, sylphx, macos, standard]
             target: aarch64-apple-darwin
-          - host: macos-latest
+          - host: [self-hosted, sylphx, macos, standard]
             target: x86_64-apple-darwin
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- Product Darwin native-build/release legs now use `[self-hosted, sylphx, macos, standard]` only.
- Removes GitHub-hosted `macos-latest` which stranded work off the Sylphx JIT fleet.

## Test plan
- [ ] PR CI / native-build workflow validation
- [ ] Confirm no `macos-latest` in product Darwin matrices
- [ ] Observe self-hosted pickup on Darwin legs