### PR TITLE
ci: drop default merge_group (Fast Trunk MQ off)

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -25,8 +25,6 @@ on:
       - 'scripts/assemble-multiarch-natives.ts'
       - '.github/workflows/native-build.yml'
       - '.github/workflows/release.yml'
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - main # Trigger on PR to main branch
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

Fleet Fast Trunk alignment: remove default `merge_group` from ordinary CI (Merge Queue off unless intentionally enabled).

Does not change publish/release packaging authority paths.

## Test plan
- [ ] CI triggers on PR/push only
- [ ] No merge_group under `on:` for tip CI
